### PR TITLE
Fix bond display mapping and double bond stereochemistry for abbreviations

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/converter/BondConverter.java
+++ b/src/main/java/org/beilstein/chemxtract/converter/BondConverter.java
@@ -158,12 +158,12 @@ public class BondConverter {
       return IBond.Display.Solid;
     }
     return switch (cdBondDisplay) {
-      case WedgeBegin -> IBond.Display.WedgeBegin;
-      case WedgedHashBegin -> IBond.Display.WedgedHashBegin;
+      case WedgeBegin, Bold -> IBond.Display.WedgeBegin;
+      case WedgedHashBegin, Hash -> IBond.Display.WedgedHashBegin;
       case WedgeEnd -> IBond.Display.WedgeEnd;
       case WedgedHashEnd -> IBond.Display.WedgedHashEnd;
-      case Bold -> IBond.Display.Bold;
-      case Hash -> IBond.Display.Hash;
+      //      case Bold -> IBond.Display.Bold;
+      //      case Hash -> IBond.Display.Hash;
       case Wavy -> IBond.Display.Wavy;
       case Dash -> IBond.Display.Dash;
       default -> IBond.Display.Solid;

--- a/src/main/java/org/beilstein/chemxtract/converter/FragmentConverter.java
+++ b/src/main/java/org/beilstein/chemxtract/converter/FragmentConverter.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.beilstein.chemxtract.cdx.CDAtom;
 import org.beilstein.chemxtract.cdx.CDBond;
 import org.beilstein.chemxtract.cdx.CDFragment;
+import org.beilstein.chemxtract.cdx.datatypes.CDBondCIPType;
 import org.beilstein.chemxtract.cdx.datatypes.CDBondOrder;
 import org.beilstein.chemxtract.cdx.datatypes.CDNodeType;
 import org.beilstein.chemxtract.cdx.datatypes.CDRadical;
@@ -130,6 +131,17 @@ public class FragmentConverter {
     // get bonds
     BondVisitor bondVisitor = new BondVisitor(fragment, rawMode);
     List<CDBond> cdBonds = bondVisitor.getBonds();
+
+    // check for double bonds in single atom 'label abbreviations' like 'AcOK'
+    // TODO: change this behavior after adding a parent field to CDObject
+    if (fragment.getAtoms().size() == 1) {
+      cdBonds.forEach(
+          b -> {
+            if (b.getBondOrder() == CDBondOrder.Double
+                && b.getStereochemistry() == CDBondCIPType.Undetermined)
+              b.setStereochemistry(CDBondCIPType.None);
+          });
+    }
 
     // convert CDAtoms to IAtoms
     AtomConverter atomConverter = new AtomConverter(builder, mode);

--- a/src/test/java/org/beilstein/chemxtract/converter/BondConverterTest.java
+++ b/src/test/java/org/beilstein/chemxtract/converter/BondConverterTest.java
@@ -94,12 +94,22 @@ public class BondConverterTest {
     assertEquals(IBond.Display.Dash, result.getDisplay());
   }
 
+  @Ignore
+  @Deprecated
   @Test
   public void singleHashBondTest() throws CDKException {
     CDBond cdBond = mockBond(CDBondOrder.Single, CDBondDisplay.Hash, null);
     IBond result = converter.convert(cdBond);
     assertEquals(IBond.Order.SINGLE, result.getOrder());
     assertEquals(IBond.Display.Hash, result.getDisplay());
+  }
+
+  @Test
+  public void singleHashBondToWedgeHashBeginTest() throws CDKException {
+    CDBond cdBond = mockBond(CDBondOrder.Single, CDBondDisplay.Hash, null);
+    IBond result = converter.convert(cdBond);
+    assertEquals(IBond.Order.SINGLE, result.getOrder());
+    assertEquals(IBond.Display.WedgedHashBegin, result.getDisplay());
   }
 
   @Test
@@ -118,12 +128,22 @@ public class BondConverterTest {
     assertEquals(IBond.Display.WedgedHashEnd, result.getDisplay());
   }
 
+  @Ignore
+  @Deprecated
   @Test
   public void singleBoldBondTest() throws CDKException {
     CDBond cdBond = mockBond(CDBondOrder.Single, CDBondDisplay.Bold, null);
     IBond result = converter.convert(cdBond);
     assertEquals(IBond.Order.SINGLE, result.getOrder());
     assertEquals(IBond.Display.Bold, result.getDisplay());
+  }
+
+  @Test
+  public void singleBoldBondToWedgeBeginTest() throws CDKException {
+    CDBond cdBond = mockBond(CDBondOrder.Single, CDBondDisplay.Bold, null);
+    IBond result = converter.convert(cdBond);
+    assertEquals(IBond.Order.SINGLE, result.getOrder());
+    assertEquals(IBond.Display.WedgeBegin, result.getDisplay());
   }
 
   @Test


### PR DESCRIPTION
Summary                                                
                                                                                                                                                                                                                                                                                                          
- Bold/Hash bond remapping: Bold bond display is now mapped to WedgeBegin and Hash to WedgedHashBegin, aligning CDX bond displays with standard stereo representations. The previous pass-through of Bold/Hash as distinct display types is deprecated.                                                 
- Double bond stereochemistry suppression: For single-atom label abbreviations (e.g. AcOK), double bonds with Undetermined CIP stereochemistry are now set to None to prevent incorrect stereo output.
                                                                                                                                                                                                                                                                                                          
Test changes                                           
                                                                                                                                                                                                                                                                                                         
- Added singleHashBondToWedgeHashBeginTest and singleBoldBondToWedgeBeginTest to cover the new mappings.                                                                                                                                                                                                
- Marked the old singleHashBondTest and singleBoldBondTest as @Ignore / @Deprecated since the prior behavior is no longer correct.