### PR TITLE
refactor: set bond display within switch cases instead of post-switch…

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/converter/BondConverter.java
+++ b/src/main/java/org/beilstein/chemxtract/converter/BondConverter.java
@@ -103,9 +103,11 @@ public class BondConverter {
     switch (cdOrder) {
       case Single:
         bond.setOrder(IBond.Order.SINGLE);
+        bond.setDisplay(convertSingleBondDisplay(source.getBondDisplay()));
         break;
       case Double:
         bond.setOrder(IBond.Order.DOUBLE);
+        bond.setDisplay(convertDoubleBondStereoToCDKDisplay(source.getStereochemistry()));
         break;
       case Triple:
         bond.setOrder(IBond.Order.TRIPLE);
@@ -131,14 +133,6 @@ public class BondConverter {
         break;
       default:
         throw new CDKException("Unsupported bond type: " + cdOrder.name());
-    }
-    // set single bond display type
-    if (IBond.Order.SINGLE.equals(bond.getOrder())) {
-      bond.setDisplay(convertSingleBondDisplay(source.getBondDisplay()));
-    }
-    // set double bond stereo
-    else if (IBond.Order.DOUBLE.equals(bond.getOrder())) {
-      bond.setDisplay(convertDoubleBondStereoToCDKDisplay(source.getStereochemistry()));
     }
     bondMap.putIfAbsent(source, bond);
     return bond;


### PR DESCRIPTION
… if-else

<!--
Thank you for contributing to BChemXtract!

PR titles MUST follow Conventional Commits — release-please uses them
to drive versioning and the CHANGELOG. Examples:
  feat: add support for ChemDraw 23 abbreviations
  fix: NPE in BCXReactionInfo when no products
  feat!: drop Java 11 support     (the `!` marks a breaking change)

Allowed types: feat, fix, perf, revert, build, chore, ci, docs, refactor,
                style, test
-->

## Summary

- Move setDisplay calls into the Single and Double switch cases, eliminating a redundant post-switch if-else block                                                                                                                                                                                      
- Keeps display logic co-located with the bond order assignment, making the relationship between order and display explicit                                                                                                                                                                             
- Reduces cognitive overhead: no need to trace control flow past the switch to understand what gets set
 
## Type of change

- [ ] feat — new feature (minor bump)
- [ ] fix — bug fix (patch bump)
- [ ] perf — performance improvement (patch bump)
- [ ] BREAKING CHANGE — incompatible change (`!` in title or footer; major bump)
- [x] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [x] PR title follows Conventional Commits
- [x] `mvn -B verify` passes locally
- [x] `mvn spotless:apply` was run (or `mvn spotless:check` is clean)
- [ ] New behavior is covered by tests
- [ ] Public API changes are documented (Javadoc + README/HOWTO if applicable)

## Related issues

<!-- Closes #123, refs #456, etc. -->
