### PR TITLE
ci(release-please): unhide docs section in CHANGELOG

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,7 +21,7 @@
         { "type": "build",    "section": "Build System",                 "hidden": true },
         { "type": "chore",    "section": "Miscellaneous Chores",         "hidden": true },
         { "type": "ci",       "section": "Continuous Integration",       "hidden": true },
-        { "type": "docs",     "section": "Documentation",                "hidden": true },
+        { "type": "docs",     "section": "Documentation"                                 },
         { "type": "refactor", "section": "Code Refactoring",             "hidden": true },
         { "type": "style",    "section": "Styles",                       "hidden": true },
         { "type": "test",     "section": "Tests",                        "hidden": true }


### PR DESCRIPTION
Surface docs: commits in the generated CHANGELOG under a "Documentation" section. docs commits still do not trigger a version bump (only feat/fix/perf/BREAKING CHANGE do) — they will only appear under an existing release that is being cut for other reasons.

refactor/build/ci/chore/style/test remain hidden by design: they are internal-only and would add noise for downstream Maven Central consumers.

<!--
Thank you for contributing to BChemXtract!

PR titles MUST follow Conventional Commits — release-please uses them
to drive versioning and the CHANGELOG. Examples:
  feat: add support for ChemDraw 23 abbreviations
  fix: NPE in BCXReactionInfo when no products
  feat!: drop Java 11 support     (the `!` marks a breaking change)

Allowed types: feat, fix, perf, revert, build, chore, ci, docs, refactor,
                style, test
-->

## Summary

<!-- 1–3 bullets describing the change and the motivation. -->

## Type of change

- [ ] feat — new feature (minor bump)
- [ ] fix — bug fix (patch bump)
- [ ] perf — performance improvement (patch bump)
- [ ] BREAKING CHANGE — incompatible change (`!` in title or footer; major bump)
- [ ] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [ ] PR title follows Conventional Commits
- [ ] `mvn -B verify` passes locally
- [ ] `mvn spotless:apply` was run (or `mvn spotless:check` is clean)
- [ ] New behavior is covered by tests
- [ ] Public API changes are documented (Javadoc + README/HOWTO if applicable)

## Related issues

<!-- Closes #123, refs #456, etc. -->
