### PR TITLE
chore: fix 172 CodeQL code-scanning alerts

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/cdx/CDAltGroup.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDAltGroup.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -45,27 +46,39 @@ public class CDAltGroup extends CDObject {
   private int valence;
 
   public List<CDGroup> getGroups() {
-    return groups;
+    return Collections.unmodifiableList(groups);
   }
 
   public void setGroups(List<CDGroup> groups) {
-    this.groups = groups;
+    this.groups = groups == null ? new ArrayList<>() : new ArrayList<>(groups);
+  }
+
+  public void addGroup(CDGroup group) {
+    this.groups.add(group);
   }
 
   public List<CDFragment> getFragments() {
-    return fragments;
+    return Collections.unmodifiableList(fragments);
   }
 
   public void setFragments(List<CDFragment> fragments) {
-    this.fragments = fragments;
+    this.fragments = fragments == null ? new ArrayList<>() : new ArrayList<>(fragments);
+  }
+
+  public void addFragment(CDFragment fragment) {
+    this.fragments.add(fragment);
   }
 
   public List<CDText> getCaptions() {
-    return captions;
+    return Collections.unmodifiableList(captions);
   }
 
   public void setCaptions(List<CDText> captions) {
-    this.captions = captions;
+    this.captions = captions == null ? new ArrayList<>() : new ArrayList<>(captions);
+  }
+
+  public void addCaption(CDText caption) {
+    this.captions.add(caption);
   }
 
   public CDRectangle getTextFrame() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDAtom.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDAtom.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.*;
 
@@ -145,11 +146,15 @@ public class CDAtom extends CDObject {
   private CDGenericList genericList;
 
   public List<CDFragment> getFragments() {
-    return fragments;
+    return Collections.unmodifiableList(fragments);
   }
 
   public void setFragments(List<CDFragment> fragments) {
-    this.fragments = fragments;
+    this.fragments = fragments == null ? new ArrayList<>() : new ArrayList<>(fragments);
+  }
+
+  public void addFragment(CDFragment fragment) {
+    this.fragments.add(fragment);
   }
 
   public CDText getText() {
@@ -321,19 +326,19 @@ public class CDAtom extends CDObject {
   }
 
   public List<CDBond> getBondOrdering() {
-    return bondOrdering;
+    return bondOrdering == null ? null : Collections.unmodifiableList(bondOrdering);
   }
 
   public void setBondOrdering(List<CDBond> bondOrdering) {
-    this.bondOrdering = bondOrdering;
+    this.bondOrdering = bondOrdering == null ? null : new ArrayList<>(bondOrdering);
   }
 
   public List<CDAtom> getAttachedAtoms() {
-    return attachedAtoms;
+    return attachedAtoms == null ? null : Collections.unmodifiableList(attachedAtoms);
   }
 
   public void setAttachedAtoms(List<CDAtom> attachedAtoms) {
-    this.attachedAtoms = attachedAtoms;
+    this.attachedAtoms = attachedAtoms == null ? null : new ArrayList<>(attachedAtoms);
   }
 
   public String getLabelText() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDBond.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDBond.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -167,11 +168,12 @@ public class CDBond extends CDObject {
   }
 
   public List<CDBond> getBondCircularOrdering() {
-    return bondCircularOrdering;
+    return bondCircularOrdering == null ? null : Collections.unmodifiableList(bondCircularOrdering);
   }
 
   public void setBondCircularOrdering(List<CDBond> bondCircularOrdering) {
-    this.bondCircularOrdering = bondCircularOrdering;
+    this.bondCircularOrdering =
+        bondCircularOrdering == null ? null : new ArrayList<>(bondCircularOrdering);
   }
 
   public Set<CDBond> getCrossingBonds() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDBracket.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDBracket.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDBracketUsage;
 import org.beilstein.chemxtract.cdx.datatypes.CDPolymerFlipType;
@@ -55,19 +56,28 @@ public class CDBracket extends CDObject {
   private List<Object> bracketedObjects = new ArrayList<>();
 
   public List<CDBracket> getBrackets() {
-    return brackets;
+    return Collections.unmodifiableList(brackets);
   }
 
   public void setBrackets(List<CDBracket> brackets) {
-    this.brackets = brackets;
+    this.brackets = brackets == null ? new ArrayList<>() : new ArrayList<>(brackets);
+  }
+
+  public void addBracket(CDBracket bracket) {
+    this.brackets.add(bracket);
   }
 
   public List<CDBracketAttachment> getBracketAttachments() {
-    return bracketAttachments;
+    return Collections.unmodifiableList(bracketAttachments);
   }
 
   public void setBracketAttachments(List<CDBracketAttachment> bracketAttachments) {
-    this.bracketAttachments = bracketAttachments;
+    this.bracketAttachments =
+        bracketAttachments == null ? new ArrayList<>() : new ArrayList<>(bracketAttachments);
+  }
+
+  public void addBracketAttachment(CDBracketAttachment bracketAttachment) {
+    this.bracketAttachments.add(bracketAttachment);
   }
 
   public CDBracketUsage getBracketUsage() {
@@ -95,11 +105,16 @@ public class CDBracket extends CDObject {
   }
 
   public List<Object> getBracketedObjects() {
-    return bracketedObjects;
+    return Collections.unmodifiableList(bracketedObjects);
   }
 
   public void setBracketedObjects(List<Object> bracketedObjects) {
-    this.bracketedObjects = bracketedObjects;
+    this.bracketedObjects =
+        bracketedObjects == null ? new ArrayList<>() : new ArrayList<>(bracketedObjects);
+  }
+
+  public void addBracketedObject(Object bracketedObject) {
+    this.bracketedObjects.add(bracketedObject);
   }
 
   public double getRepeatCount() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDBracketAttachment.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDBracketAttachment.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Specifies an external connection for a bracket. */
@@ -31,11 +32,15 @@ public class CDBracketAttachment {
   private CDGraphic graphic;
 
   public List<CDCrossingBond> getCrossingBonds() {
-    return crossingBonds;
+    return Collections.unmodifiableList(crossingBonds);
   }
 
   public void setCrossingBonds(List<CDCrossingBond> crossingBonds) {
-    this.crossingBonds = crossingBonds;
+    this.crossingBonds = crossingBonds == null ? new ArrayList<>() : new ArrayList<>(crossingBonds);
+  }
+
+  public void addCrossingBond(CDCrossingBond crossingBond) {
+    this.crossingBonds.add(crossingBond);
   }
 
   public CDGraphic getGraphic() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDChemicalProperty.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDChemicalProperty.java
@@ -21,6 +21,8 @@
  */
 package org.beilstein.chemxtract.cdx;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Physical or chemical property that corresponds to a group of atoms or bonds. */
@@ -32,11 +34,11 @@ public class CDChemicalProperty {
   private boolean active = false;
 
   public List<Object> getBasisObjects() {
-    return basisObjects;
+    return basisObjects == null ? null : Collections.unmodifiableList(basisObjects);
   }
 
   public void setBasisObjects(List<Object> basisObjects) {
-    this.basisObjects = basisObjects;
+    this.basisObjects = basisObjects == null ? null : new ArrayList<>(basisObjects);
   }
 
   public long getType() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDConstraint.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDConstraint.java
@@ -21,6 +21,8 @@
  */
 package org.beilstein.chemxtract.cdx;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDConstraintType;
 
@@ -60,11 +62,11 @@ public class CDConstraint extends CDObject {
   }
 
   public List<Object> getBasisObjects() {
-    return basisObjects;
+    return basisObjects == null ? null : Collections.unmodifiableList(basisObjects);
   }
 
   public void setBasisObjects(List<Object> basisObjects) {
-    this.basisObjects = basisObjects;
+    this.basisObjects = basisObjects == null ? null : new ArrayList<>(basisObjects);
   }
 
   public CDConstraintType getConstraintType() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDDocument.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDDocument.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDPoint2D;
@@ -196,11 +197,15 @@ public class CDDocument {
   }
 
   public List<CDPage> getPages() {
-    return pages;
+    return Collections.unmodifiableList(pages);
   }
 
   public void setPages(List<CDPage> pages) {
-    this.pages = pages;
+    this.pages = pages == null ? new ArrayList<>() : new ArrayList<>(pages);
+  }
+
+  public void addPage(CDPage page) {
+    this.pages.add(page);
   }
 
   public byte[] getMacPrintInfo() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDDocumentUtils.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDDocumentUtils.java
@@ -422,7 +422,7 @@ public class CDDocumentUtils {
         label = text;
       }
     }
-    if (label != null) fragment.getTexts().add(label);
+    if (label != null) fragment.addText(label);
   }
 
   /**

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDFragment.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDFragment.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.beilstein.chemxtract.cdx.datatypes.CDNodeType;
@@ -69,59 +70,92 @@ public class CDFragment extends CDObject {
   private CDSequenceType sequenceType = CDSequenceType.Unknown;
 
   public List<CDAtom> getAtoms() {
-    return atoms;
+    return Collections.unmodifiableList(atoms);
   }
 
   public void setAtoms(List<CDAtom> atoms) {
-    this.atoms = atoms;
+    this.atoms = atoms == null ? new ArrayList<>() : new ArrayList<>(atoms);
+  }
+
+  public void addAtom(CDAtom atom) {
+    this.atoms.add(atom);
+  }
+
+  public void addAllAtoms(java.util.Collection<? extends CDAtom> atoms) {
+    this.atoms.addAll(atoms);
   }
 
   public List<CDBond> getBonds() {
-    return bonds;
+    return Collections.unmodifiableList(bonds);
   }
 
   public void setBonds(List<CDBond> bonds) {
-    this.bonds = bonds;
+    this.bonds = bonds == null ? new ArrayList<>() : new ArrayList<>(bonds);
+  }
+
+  public void addBond(CDBond bond) {
+    this.bonds.add(bond);
   }
 
   public List<CDGraphic> getGraphics() {
-    return graphics;
+    return Collections.unmodifiableList(graphics);
   }
 
   public void setGraphics(List<CDGraphic> graphics) {
-    this.graphics = graphics;
+    this.graphics = graphics == null ? new ArrayList<>() : new ArrayList<>(graphics);
+  }
+
+  public void addGraphic(CDGraphic graphic) {
+    this.graphics.add(graphic);
   }
 
   public List<CDSpline> getCurves() {
-    return curves;
+    return Collections.unmodifiableList(curves);
   }
 
   public void setCurves(List<CDSpline> curves) {
-    this.curves = curves;
+    this.curves = curves == null ? new ArrayList<>() : new ArrayList<>(curves);
+  }
+
+  public void addCurve(CDSpline curve) {
+    this.curves.add(curve);
   }
 
   public List<CDText> getTexts() {
-    return texts;
+    return Collections.unmodifiableList(texts);
   }
 
   public void setTexts(List<CDText> texts) {
-    this.texts = texts;
+    this.texts = texts == null ? new ArrayList<>() : new ArrayList<>(texts);
+  }
+
+  public void addText(CDText text) {
+    this.texts.add(text);
   }
 
   public List<CDArrow> getArrows() {
-    return arrows;
+    return Collections.unmodifiableList(arrows);
   }
 
   public void setArrows(List<CDArrow> arrows) {
-    this.arrows = arrows;
+    this.arrows = arrows == null ? new ArrayList<>() : new ArrayList<>(arrows);
+  }
+
+  public void addArrow(CDArrow arrow) {
+    this.arrows.add(arrow);
   }
 
   public List<CDColoredMolecularArea> getColoredMolecularAreas() {
-    return coloredMolecularAreas;
+    return Collections.unmodifiableList(coloredMolecularAreas);
   }
 
   public void setColoredMolecularAreas(List<CDColoredMolecularArea> coloredMolecularAreas) {
-    this.coloredMolecularAreas = coloredMolecularAreas;
+    this.coloredMolecularAreas =
+        coloredMolecularAreas == null ? new ArrayList<>() : new ArrayList<>(coloredMolecularAreas);
+  }
+
+  public void addColoredMolecularArea(CDColoredMolecularArea coloredMolecularArea) {
+    this.coloredMolecularAreas.add(coloredMolecularArea);
   }
 
   public boolean isRacemic() {
@@ -157,11 +191,16 @@ public class CDFragment extends CDObject {
   }
 
   public List<CDAtom> getConnectionOrder() {
-    return connectionOrder;
+    return Collections.unmodifiableList(connectionOrder);
   }
 
   public void setConnectionOrder(List<CDAtom> connectionOrder) {
-    this.connectionOrder = connectionOrder;
+    this.connectionOrder =
+        connectionOrder == null ? new ArrayList<>() : new ArrayList<>(connectionOrder);
+  }
+
+  public void addConnectionOrder(CDAtom atom) {
+    this.connectionOrder.add(atom);
   }
 
   public byte[] getFormula() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDGeometry.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDGeometry.java
@@ -21,6 +21,8 @@
  */
 package org.beilstein.chemxtract.cdx;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDGeometryType;
 
@@ -63,11 +65,11 @@ public class CDGeometry extends CDObject {
   }
 
   public List<Object> getBasisObjects() {
-    return basisObjects;
+    return basisObjects == null ? null : Collections.unmodifiableList(basisObjects);
   }
 
   public void setBasisObjects(List<Object> basisObjects) {
-    this.basisObjects = basisObjects;
+    this.basisObjects = basisObjects == null ? null : new ArrayList<>(basisObjects);
   }
 
   public boolean isPointIsDirected() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDGroup.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDGroup.java
@@ -113,7 +113,9 @@ public class CDGroup extends CDObject {
 
   public void setNamedAlternativeGroups(List<CDAltGroup> namedAlternativeGroups) {
     altGroups =
-        namedAlternativeGroups == null ? new ArrayList<>() : new ArrayList<>(namedAlternativeGroups);
+        namedAlternativeGroups == null
+            ? new ArrayList<>()
+            : new ArrayList<>(namedAlternativeGroups);
   }
 
   public void addNamedAlternativeGroup(CDAltGroup namedAlternativeGroup) {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDGroup.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDGroup.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** An object for grouping several other objects. */
@@ -47,83 +48,125 @@ public class CDGroup extends CDObject {
   private List<CDArrow> arrows = new ArrayList<>();
 
   public List<CDGroup> getGroups() {
-    return groups;
+    return Collections.unmodifiableList(groups);
   }
 
   public void setGroups(List<CDGroup> groups) {
-    this.groups = groups;
+    this.groups = groups == null ? new ArrayList<>() : new ArrayList<>(groups);
+  }
+
+  public void addGroup(CDGroup group) {
+    this.groups.add(group);
   }
 
   public List<CDFragment> getFragments() {
-    return fragments;
+    return Collections.unmodifiableList(fragments);
   }
 
   public void setFragments(List<CDFragment> fragments) {
-    this.fragments = fragments;
+    this.fragments = fragments == null ? new ArrayList<>() : new ArrayList<>(fragments);
+  }
+
+  public void addFragment(CDFragment fragment) {
+    this.fragments.add(fragment);
   }
 
   public List<CDText> getCaptions() {
-    return captions;
+    return Collections.unmodifiableList(captions);
   }
 
   public void setCaptions(List<CDText> captions) {
-    this.captions = captions;
+    this.captions = captions == null ? new ArrayList<>() : new ArrayList<>(captions);
+  }
+
+  public void addCaption(CDText caption) {
+    this.captions.add(caption);
   }
 
   public List<CDGraphic> getGraphics() {
-    return graphics;
+    return Collections.unmodifiableList(graphics);
   }
 
   public void setGraphics(List<CDGraphic> graphics) {
-    this.graphics = graphics;
+    this.graphics = graphics == null ? new ArrayList<>() : new ArrayList<>(graphics);
+  }
+
+  public void addGraphic(CDGraphic graphic) {
+    this.graphics.add(graphic);
   }
 
   public List<CDSpline> getCurves() {
-    return curves;
+    return Collections.unmodifiableList(curves);
   }
 
   public void setCurves(List<CDSpline> curves) {
-    this.curves = curves;
+    this.curves = curves == null ? new ArrayList<>() : new ArrayList<>(curves);
+  }
+
+  public void addCurve(CDSpline curve) {
+    this.curves.add(curve);
   }
 
   public List<CDAltGroup> getNamedAlternativeGroups() {
-    return altGroups;
+    return Collections.unmodifiableList(altGroups);
   }
 
   public void setNamedAlternativeGroups(List<CDAltGroup> namedAlternativeGroups) {
-    altGroups = namedAlternativeGroups;
+    altGroups =
+        namedAlternativeGroups == null ? new ArrayList<>() : new ArrayList<>(namedAlternativeGroups);
+  }
+
+  public void addNamedAlternativeGroup(CDAltGroup namedAlternativeGroup) {
+    this.altGroups.add(namedAlternativeGroup);
   }
 
   public List<CDReactionStep> getReactionSteps() {
-    return reactionSteps;
+    return Collections.unmodifiableList(reactionSteps);
   }
 
   public void setReactionSteps(List<CDReactionStep> reactionSteps) {
-    this.reactionSteps = reactionSteps;
+    this.reactionSteps = reactionSteps == null ? new ArrayList<>() : new ArrayList<>(reactionSteps);
+  }
+
+  public void addReactionStep(CDReactionStep reactionStep) {
+    this.reactionSteps.add(reactionStep);
   }
 
   public List<CDSpectrum> getSpectra() {
-    return spectra;
+    return Collections.unmodifiableList(spectra);
   }
 
   public void setSpectra(List<CDSpectrum> spectra) {
-    this.spectra = spectra;
+    this.spectra = spectra == null ? new ArrayList<>() : new ArrayList<>(spectra);
+  }
+
+  public void addSpectrum(CDSpectrum spectrum) {
+    this.spectra.add(spectrum);
   }
 
   public List<CDPicture> getEmbeddedObjects() {
-    return embeddedObjects;
+    return Collections.unmodifiableList(embeddedObjects);
   }
 
   public void setEmbeddedObjects(List<CDPicture> embeddedObjects) {
-    this.embeddedObjects = embeddedObjects;
+    this.embeddedObjects =
+        embeddedObjects == null ? new ArrayList<>() : new ArrayList<>(embeddedObjects);
+  }
+
+  public void addEmbeddedObject(CDPicture embeddedObject) {
+    this.embeddedObjects.add(embeddedObject);
   }
 
   public List<CDArrow> getArrows() {
-    return arrows;
+    return Collections.unmodifiableList(arrows);
   }
 
   public void setArrows(List<CDArrow> arrows) {
-    this.arrows = arrows;
+    this.arrows = arrows == null ? new ArrayList<>() : new ArrayList<>(arrows);
+  }
+
+  public void addArrow(CDArrow arrow) {
+    this.arrows.add(arrow);
   }
 
   public boolean isIntegral() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDObject.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDObject.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDColor;
 
@@ -52,11 +53,15 @@ public abstract class CDObject {
   private final CDSettings settings = new CDSettings();
 
   public List<CDObjectTag> getObjectTags() {
-    return objectTags;
+    return Collections.unmodifiableList(objectTags);
   }
 
   public void setObjectTags(List<CDObjectTag> objectTags) {
-    this.objectTags = objectTags;
+    this.objectTags = objectTags == null ? new ArrayList<>() : new ArrayList<>(objectTags);
+  }
+
+  public void addObjectTag(CDObjectTag objectTag) {
+    this.objectTags.add(objectTag);
   }
 
   public int getZOrder() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDObjectTag.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDObjectTag.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDObjectTagType;
 import org.beilstein.chemxtract.cdx.datatypes.CDPoint2D;
@@ -55,11 +56,15 @@ public class CDObjectTag extends CDObject {
   private Object value;
 
   public List<CDText> getTexts() {
-    return texts;
+    return Collections.unmodifiableList(texts);
   }
 
   public void setTexts(List<CDText> texts) {
-    this.texts = texts;
+    this.texts = texts == null ? new ArrayList<>() : new ArrayList<>(texts);
+  }
+
+  public void addText(CDText text) {
+    this.texts.add(text);
   }
 
   public String getName() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDPage.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDPage.java
@@ -169,7 +169,9 @@ public class CDPage extends CDObject {
 
   public void setNamedAlternativeGroups(List<CDAltGroup> namedAlternativeGroups) {
     this.namedAlternativeGroups =
-        namedAlternativeGroups == null ? new ArrayList<>() : new ArrayList<>(namedAlternativeGroups);
+        namedAlternativeGroups == null
+            ? new ArrayList<>()
+            : new ArrayList<>(namedAlternativeGroups);
   }
 
   public void addNamedAlternativeGroup(CDAltGroup namedAlternativeGroup) {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDPage.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDPage.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDDrawingSpaceType;
 import org.beilstein.chemxtract.cdx.datatypes.CDPageDefinition;
@@ -65,171 +66,261 @@ public class CDPage extends CDObject {
   private CDRectangle boundsInParent;
 
   public List<CDGroup> getGroups() {
-    return groups;
+    return Collections.unmodifiableList(groups);
   }
 
   public void setGroups(List<CDGroup> groups) {
-    this.groups = groups;
+    this.groups = groups == null ? new ArrayList<>() : new ArrayList<>(groups);
+  }
+
+  public void addGroup(CDGroup group) {
+    this.groups.add(group);
   }
 
   public List<CDFragment> getFragments() {
-    return fragments;
+    return Collections.unmodifiableList(fragments);
   }
 
   public void setFragments(List<CDFragment> fragments) {
-    this.fragments = fragments;
+    this.fragments = fragments == null ? new ArrayList<>() : new ArrayList<>(fragments);
+  }
+
+  public void addFragment(CDFragment fragment) {
+    this.fragments.add(fragment);
   }
 
   public List<CDText> getTexts() {
-    return texts;
+    return Collections.unmodifiableList(texts);
   }
 
   public void setTexts(List<CDText> texts) {
-    this.texts = texts;
+    this.texts = texts == null ? new ArrayList<>() : new ArrayList<>(texts);
+  }
+
+  public void addText(CDText text) {
+    this.texts.add(text);
   }
 
   public List<CDGraphic> getGraphics() {
-    return graphics;
+    return Collections.unmodifiableList(graphics);
   }
 
   public void setGraphics(List<CDGraphic> graphics) {
-    this.graphics = graphics;
+    this.graphics = graphics == null ? new ArrayList<>() : new ArrayList<>(graphics);
+  }
+
+  public void addGraphic(CDGraphic graphic) {
+    this.graphics.add(graphic);
   }
 
   public List<CDBracket> getBracketedGroups() {
-    return bracketedGroups;
+    return Collections.unmodifiableList(bracketedGroups);
   }
 
   public void setBracketedGroups(List<CDBracket> bracketedGroups) {
-    this.bracketedGroups = bracketedGroups;
+    this.bracketedGroups =
+        bracketedGroups == null ? new ArrayList<>() : new ArrayList<>(bracketedGroups);
+  }
+
+  public void addBracketedGroup(CDBracket bracketedGroup) {
+    this.bracketedGroups.add(bracketedGroup);
   }
 
   public List<CDSpline> getCurves() {
-    return curves;
+    return Collections.unmodifiableList(curves);
   }
 
   public void setCurves(List<CDSpline> curves) {
-    this.curves = curves;
+    this.curves = curves == null ? new ArrayList<>() : new ArrayList<>(curves);
+  }
+
+  public void addCurve(CDSpline curve) {
+    this.curves.add(curve);
   }
 
   public List<CDPicture> getEmbeddedObjects() {
-    return embeddedObjects;
+    return Collections.unmodifiableList(embeddedObjects);
   }
 
   public void setEmbeddedObjects(List<CDPicture> embeddedObjects) {
-    this.embeddedObjects = embeddedObjects;
+    this.embeddedObjects =
+        embeddedObjects == null ? new ArrayList<>() : new ArrayList<>(embeddedObjects);
+  }
+
+  public void addEmbeddedObject(CDPicture embeddedObject) {
+    this.embeddedObjects.add(embeddedObject);
   }
 
   public List<CDTable> getTables() {
-    return tables;
+    return Collections.unmodifiableList(tables);
   }
 
   public void setTables(List<CDTable> tables) {
-    this.tables = tables;
+    this.tables = tables == null ? new ArrayList<>() : new ArrayList<>(tables);
+  }
+
+  public void addTable(CDTable table) {
+    this.tables.add(table);
   }
 
   public List<CDAltGroup> getNamedAlternativeGroups() {
-    return namedAlternativeGroups;
+    return Collections.unmodifiableList(namedAlternativeGroups);
   }
 
   public void setNamedAlternativeGroups(List<CDAltGroup> namedAlternativeGroups) {
-    this.namedAlternativeGroups = namedAlternativeGroups;
+    this.namedAlternativeGroups =
+        namedAlternativeGroups == null ? new ArrayList<>() : new ArrayList<>(namedAlternativeGroups);
+  }
+
+  public void addNamedAlternativeGroup(CDAltGroup namedAlternativeGroup) {
+    this.namedAlternativeGroups.add(namedAlternativeGroup);
   }
 
   public List<CDReactionScheme> getReactionSchemes() {
-    return reactionSchemes;
+    return Collections.unmodifiableList(reactionSchemes);
   }
 
   public void setReactionSchemes(List<CDReactionScheme> reactionSchemes) {
-    this.reactionSchemes = reactionSchemes;
+    this.reactionSchemes =
+        reactionSchemes == null ? new ArrayList<>() : new ArrayList<>(reactionSchemes);
+  }
+
+  public void addReactionScheme(CDReactionScheme reactionScheme) {
+    this.reactionSchemes.add(reactionScheme);
   }
 
   public List<CDReactionStep> getReactionSteps() {
-    return reactionSteps;
+    return Collections.unmodifiableList(reactionSteps);
   }
 
   public void setReactionSteps(List<CDReactionStep> reactionSteps) {
-    this.reactionSteps = reactionSteps;
+    this.reactionSteps = reactionSteps == null ? new ArrayList<>() : new ArrayList<>(reactionSteps);
+  }
+
+  public void addReactionStep(CDReactionStep reactionStep) {
+    this.reactionSteps.add(reactionStep);
   }
 
   public List<CDSpectrum> getSpectra() {
-    return spectra;
+    return Collections.unmodifiableList(spectra);
   }
 
   public void setSpectra(List<CDSpectrum> spectra) {
-    this.spectra = spectra;
+    this.spectra = spectra == null ? new ArrayList<>() : new ArrayList<>(spectra);
+  }
+
+  public void addSpectrum(CDSpectrum spectrum) {
+    this.spectra.add(spectrum);
   }
 
   public List<CDSequence> getSequences() {
-    return sequences;
+    return Collections.unmodifiableList(sequences);
   }
 
   public void setSequences(List<CDSequence> sequences) {
-    this.sequences = sequences;
+    this.sequences = sequences == null ? new ArrayList<>() : new ArrayList<>(sequences);
+  }
+
+  public void addSequence(CDSequence sequence) {
+    this.sequences.add(sequence);
   }
 
   public List<CDCrossReference> getCrossReferences() {
-    return crossReferences;
+    return Collections.unmodifiableList(crossReferences);
   }
 
   public void setCrossReferences(List<CDCrossReference> crossReferences) {
-    this.crossReferences = crossReferences;
+    this.crossReferences =
+        crossReferences == null ? new ArrayList<>() : new ArrayList<>(crossReferences);
+  }
+
+  public void addCrossReference(CDCrossReference crossReference) {
+    this.crossReferences.add(crossReference);
   }
 
   public List<CDBorder> getBorders() {
-    return borders;
+    return Collections.unmodifiableList(borders);
   }
 
   public void setBorders(List<CDBorder> borders) {
-    this.borders = borders;
+    this.borders = borders == null ? new ArrayList<>() : new ArrayList<>(borders);
+  }
+
+  public void addBorder(CDBorder border) {
+    this.borders.add(border);
   }
 
   public List<CDGeometry> getGeometries() {
-    return geometries;
+    return Collections.unmodifiableList(geometries);
   }
 
   public void setGeometries(List<CDGeometry> geometries) {
-    this.geometries = geometries;
+    this.geometries = geometries == null ? new ArrayList<>() : new ArrayList<>(geometries);
+  }
+
+  public void addGeometry(CDGeometry geometry) {
+    this.geometries.add(geometry);
   }
 
   public List<CDConstraint> getConstraints() {
-    return constraints;
+    return Collections.unmodifiableList(constraints);
   }
 
   public void setConstraints(List<CDConstraint> constraints) {
-    this.constraints = constraints;
+    this.constraints = constraints == null ? new ArrayList<>() : new ArrayList<>(constraints);
+  }
+
+  public void addConstraint(CDConstraint constraint) {
+    this.constraints.add(constraint);
   }
 
   public List<CDTLCPlate> getTLCPlates() {
-    return tLCPlates;
+    return Collections.unmodifiableList(tLCPlates);
   }
 
   public void setTLCPlates(List<CDTLCPlate> plates) {
-    tLCPlates = plates;
+    tLCPlates = plates == null ? new ArrayList<>() : new ArrayList<>(plates);
+  }
+
+  public void addTLCPlate(CDTLCPlate plate) {
+    this.tLCPlates.add(plate);
   }
 
   public List<CDSplitter> getSplitters() {
-    return splitters;
+    return Collections.unmodifiableList(splitters);
   }
 
   public void setSplitters(List<CDSplitter> splitters) {
-    this.splitters = splitters;
+    this.splitters = splitters == null ? new ArrayList<>() : new ArrayList<>(splitters);
+  }
+
+  public void addSplitter(CDSplitter splitter) {
+    this.splitters.add(splitter);
   }
 
   public List<CDChemicalProperty> getChemicalProperties() {
-    return chemicalProperties;
+    return Collections.unmodifiableList(chemicalProperties);
   }
 
   public void setChemicalProperties(List<CDChemicalProperty> chemicalProperties) {
-    this.chemicalProperties = chemicalProperties;
+    this.chemicalProperties =
+        chemicalProperties == null ? new ArrayList<>() : new ArrayList<>(chemicalProperties);
+  }
+
+  public void addChemicalProperty(CDChemicalProperty chemicalProperty) {
+    this.chemicalProperties.add(chemicalProperty);
   }
 
   public List<CDArrow> getArrows() {
-    return arrows;
+    return Collections.unmodifiableList(arrows);
   }
 
   public void setArrows(List<CDArrow> arrows) {
-    this.arrows = arrows;
+    this.arrows = arrows == null ? new ArrayList<>() : new ArrayList<>(arrows);
+  }
+
+  public void addArrow(CDArrow arrow) {
+    this.arrows.add(arrow);
   }
 
   public int getWidthPages() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDReactionScheme.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDReactionScheme.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -34,11 +35,15 @@ public class CDReactionScheme extends CDObject {
   private List<CDReactionStep> steps = new ArrayList<>();
 
   public List<CDReactionStep> getSteps() {
-    return steps;
+    return Collections.unmodifiableList(steps);
   }
 
   public void setSteps(List<CDReactionStep> steps) {
-    this.steps = steps;
+    this.steps = steps == null ? new ArrayList<>() : new ArrayList<>(steps);
+  }
+
+  public void addStep(CDReactionStep step) {
+    this.steps.add(step);
   }
 
   @Override

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDReactionStep.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDReactionStep.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,51 +63,77 @@ public class CDReactionStep extends CDObject {
   }
 
   public List<Object> getReactants() {
-    return reactants;
+    return Collections.unmodifiableList(reactants);
   }
 
   public void setReactants(List<Object> reactants) {
-    this.reactants = reactants;
+    this.reactants = reactants == null ? new ArrayList<>() : new ArrayList<>(reactants);
+  }
+
+  public void addReactant(Object reactant) {
+    this.reactants.add(reactant);
   }
 
   public List<Object> getProducts() {
-    return products;
+    return Collections.unmodifiableList(products);
   }
 
   public void setProducts(List<Object> products) {
-    this.products = products;
+    this.products = products == null ? new ArrayList<>() : new ArrayList<>(products);
+  }
+
+  public void addProduct(Object product) {
+    this.products.add(product);
   }
 
   public List<Object> getPlusses() {
-    return plusses;
+    return Collections.unmodifiableList(plusses);
   }
 
   public void setPlusses(List<Object> plusses) {
-    this.plusses = plusses;
+    this.plusses = plusses == null ? new ArrayList<>() : new ArrayList<>(plusses);
+  }
+
+  public void addPlus(Object plus) {
+    this.plusses.add(plus);
   }
 
   public List<Object> getArrows() {
-    return arrows;
+    return Collections.unmodifiableList(arrows);
   }
 
   public void setArrows(List<Object> arrows) {
-    this.arrows = arrows;
+    this.arrows = arrows == null ? new ArrayList<>() : new ArrayList<>(arrows);
+  }
+
+  public void addArrow(Object arrow) {
+    this.arrows.add(arrow);
   }
 
   public List<Object> getObjectsAboveArrow() {
-    return objectsAboveArrow;
+    return Collections.unmodifiableList(objectsAboveArrow);
   }
 
   public void setObjectsAboveArrow(List<Object> objectsAboveArrow) {
-    this.objectsAboveArrow = objectsAboveArrow;
+    this.objectsAboveArrow =
+        objectsAboveArrow == null ? new ArrayList<>() : new ArrayList<>(objectsAboveArrow);
+  }
+
+  public void addObjectAboveArrow(Object objectAboveArrow) {
+    this.objectsAboveArrow.add(objectAboveArrow);
   }
 
   public List<Object> getObjectsBelowArrow() {
-    return objectsBelowArrow;
+    return Collections.unmodifiableList(objectsBelowArrow);
   }
 
   public void setObjectsBelowArrow(List<Object> objectsBelowArrow) {
-    this.objectsBelowArrow = objectsBelowArrow;
+    this.objectsBelowArrow =
+        objectsBelowArrow == null ? new ArrayList<>() : new ArrayList<>(objectsBelowArrow);
+  }
+
+  public void addObjectBelowArrow(Object objectBelowArrow) {
+    this.objectsBelowArrow.add(objectBelowArrow);
   }
 
   public Map<CDAtom, CDAtom> getAtomMapManual() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDSpline.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDSpline.java
@@ -21,6 +21,8 @@
  */
 package org.beilstein.chemxtract.cdx;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDArrowHeadPositionType;
 import org.beilstein.chemxtract.cdx.datatypes.CDArrowHeadType;
@@ -70,19 +72,19 @@ public class CDSpline extends CDObject {
   }
 
   public List<CDPoint2D> getPoints2D() {
-    return points2D;
+    return points2D == null ? null : Collections.unmodifiableList(points2D);
   }
 
   public void setPoints2D(List<CDPoint2D> points2D) {
-    this.points2D = points2D;
+    this.points2D = points2D == null ? null : new ArrayList<>(points2D);
   }
 
   public List<CDPoint3D> getPoints3D() {
-    return points3D;
+    return points3D == null ? null : Collections.unmodifiableList(points3D);
   }
 
   public void setPoints3D(List<CDPoint3D> points3D) {
-    this.points3D = points3D;
+    this.points3D = points3D == null ? null : new ArrayList<>(points3D);
   }
 
   public CDArrowHeadType getArrowHeadType() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDTLCLane.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDTLCLane.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Represents a lane of spots arranged vertically on a TLC plate. */
@@ -34,19 +35,27 @@ public class CDTLCLane {
   private boolean visible = true;
 
   public List<CDObjectTag> getObjectTags() {
-    return objectTags;
+    return Collections.unmodifiableList(objectTags);
   }
 
   public void setObjectTags(List<CDObjectTag> objectTags) {
-    this.objectTags = objectTags;
+    this.objectTags = objectTags == null ? new ArrayList<>() : new ArrayList<>(objectTags);
+  }
+
+  public void addObjectTag(CDObjectTag objectTag) {
+    this.objectTags.add(objectTag);
   }
 
   public List<CDTLCSpot> getSpots() {
-    return spots;
+    return Collections.unmodifiableList(spots);
   }
 
   public void setSpots(List<CDTLCSpot> spots) {
-    this.spots = spots;
+    this.spots = spots == null ? new ArrayList<>() : new ArrayList<>(spots);
+  }
+
+  public void addSpot(CDTLCSpot spot) {
+    this.spots.add(spot);
   }
 
   public boolean isVisible() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDTLCPlate.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDTLCPlate.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDPoint2D;
 
@@ -86,11 +87,15 @@ public class CDTLCPlate extends CDObject {
   }
 
   public List<CDTLCLane> getLanes() {
-    return lanes;
+    return Collections.unmodifiableList(lanes);
   }
 
   public void setLanes(List<CDTLCLane> lanes) {
-    this.lanes = lanes;
+    this.lanes = lanes == null ? new ArrayList<>() : new ArrayList<>(lanes);
+  }
+
+  public void addLane(CDTLCLane lane) {
+    this.lanes.add(lane);
   }
 
   public CDPoint2D getTopLeft() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDTLCSpot.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDTLCSpot.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDColor;
 import org.beilstein.chemxtract.cdx.datatypes.CDSplineType;
@@ -54,11 +55,15 @@ public class CDTLCSpot {
   private CDSplineType curveType;
 
   public List<CDObjectTag> getObjectTags() {
-    return objectTags;
+    return Collections.unmodifiableList(objectTags);
   }
 
   public void setObjectTags(List<CDObjectTag> objectTags) {
-    this.objectTags = objectTags;
+    this.objectTags = objectTags == null ? new ArrayList<>() : new ArrayList<>(objectTags);
+  }
+
+  public void addObjectTag(CDObjectTag objectTag) {
+    this.objectTags.add(objectTag);
   }
 
   public boolean isVisible() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDTable.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDTable.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** A table that is made up of several page objects (the cell content). */
@@ -29,11 +30,15 @@ public class CDTable extends CDObject {
   private List<CDPage> pages = new ArrayList<>();
 
   public List<CDPage> getPages() {
-    return pages;
+    return Collections.unmodifiableList(pages);
   }
 
   public void setPages(List<CDPage> pages) {
-    this.pages = pages;
+    this.pages = pages == null ? new ArrayList<>() : new ArrayList<>(pages);
+  }
+
+  public void addPage(CDPage page) {
+    this.pages.add(page);
   }
 
   @Override

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDText.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDText.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.datatypes.CDJustification;
 import org.beilstein.chemxtract.cdx.datatypes.CDLabelDisplay;
@@ -99,11 +100,15 @@ public class CDText extends CDObject {
   }
 
   public List<Integer> getLineStarts() {
-    return lineStarts;
+    return Collections.unmodifiableList(lineStarts);
   }
 
   public void setLineStarts(List<Integer> lineStarts) {
-    this.lineStarts = lineStarts;
+    this.lineStarts = lineStarts == null ? new ArrayList<>() : new ArrayList<>(lineStarts);
+  }
+
+  public void addLineStart(Integer lineStart) {
+    this.lineStarts.add(lineStart);
   }
 
   public CDLabelDisplay getLabelAlignment() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/CDVisitor.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/CDVisitor.java
@@ -28,7 +28,12 @@ import org.beilstein.chemxtract.cdx.datatypes.CDFont;
  * This class is used to build the "Visitor" pattern for {@link CDObject}s. For creating specific
  * visitors, implement a subclass, override the method you are interested in and pass the object to
  * the accept method of {@link CDPage}.
+ *
+ * <p>Methods on this base class are intentional no-ops: they exist to provide a default for
+ * subclasses that only override a subset of the visitor protocol. The unused parameters are part of
+ * the visitor contract.
  */
+@SuppressWarnings("unused")
 public class CDVisitor {
   public void visitDocument(CDDocument document) {
     // to be implemented in subclasses

--- a/src/main/java/org/beilstein/chemxtract/cdx/datatypes/CDElementList.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/datatypes/CDElementList.java
@@ -22,6 +22,8 @@
 package org.beilstein.chemxtract.cdx.datatypes;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,10 +43,18 @@ public class CDElementList {
   }
 
   public List<Integer> getElements() {
-    return elements;
+    return Collections.unmodifiableList(elements);
   }
 
   public void setElements(List<Integer> elements) {
-    this.elements = elements;
+    this.elements = elements == null ? new ArrayList<>() : new ArrayList<>(elements);
+  }
+
+  public void addElement(Integer element) {
+    this.elements.add(element);
+  }
+
+  public void addAllElements(Collection<? extends Integer> elements) {
+    this.elements.addAll(elements);
   }
 }

--- a/src/main/java/org/beilstein/chemxtract/cdx/datatypes/CDGenericList.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/datatypes/CDGenericList.java
@@ -22,6 +22,8 @@
 package org.beilstein.chemxtract.cdx.datatypes;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,10 +43,18 @@ public class CDGenericList {
   }
 
   public List<String> getElements() {
-    return elements;
+    return Collections.unmodifiableList(elements);
   }
 
   public void setElements(List<String> elements) {
-    this.elements = elements;
+    this.elements = elements == null ? new ArrayList<>() : new ArrayList<>(elements);
+  }
+
+  public void addElement(String element) {
+    this.elements.add(element);
+  }
+
+  public void addAllElements(Collection<? extends String> elements) {
+    this.elements.addAll(elements);
   }
 }

--- a/src/main/java/org/beilstein/chemxtract/cdx/datatypes/CDStyledString.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/datatypes/CDStyledString.java
@@ -22,6 +22,8 @@
 package org.beilstein.chemxtract.cdx.datatypes;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /** This class allows to store chunks of text with different text styles. */
@@ -30,11 +32,19 @@ public class CDStyledString {
   private List<CDXChunk> chunks = new ArrayList<>();
 
   public List<CDXChunk> getChunks() {
-    return chunks;
+    return Collections.unmodifiableList(chunks);
   }
 
   public void setChunks(List<CDXChunk> chunks) {
-    this.chunks = chunks;
+    this.chunks = chunks == null ? new ArrayList<>() : new ArrayList<>(chunks);
+  }
+
+  public void addChunk(CDXChunk chunk) {
+    this.chunks.add(chunk);
+  }
+
+  public void addAllChunks(Collection<? extends CDXChunk> chunks) {
+    this.chunks.addAll(chunks);
   }
 
   public String getText() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLReader.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLReader.java
@@ -77,7 +77,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Page)) {
-        document.getPages().add(createPageObject(object));
+        document.addPage(createPageObject(object));
       } else if (name.equals(CDXMLObj_TemplateGrid)) {
         document.setTemplateGrid(createTemplateGridObject(object));
       } else if (name.equals(CDXMLObj_ColorTable)) {
@@ -297,47 +297,47 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Group)) {
-        page.getGroups().add(createGroupObject(object));
+        page.addGroup(createGroupObject(object));
       } else if (name.equals(CDXMLObj_Fragment)) {
-        page.getFragments().add(createFragmentObject(object));
+        page.addFragment(createFragmentObject(object));
       } else if (name.equals(CDXMLObj_Text)) {
-        page.getTexts().add(createTextObject(object));
+        page.addText(createTextObject(object));
       } else if (name.equals(CDXMLObj_Graphic)) {
-        page.getGraphics().add(createGraphicObject(object));
+        page.addGraphic(createGraphicObject(object));
       } else if (name.equals(CDXMLObj_Arrow)) {
-        page.getArrows().add(createArrowObject(object));
+        page.addArrow(createArrowObject(object));
       } else if (name.equals(CDXMLObj_BracketedGroup)) {
-        page.getBracketedGroups().add(createBracketedGroupObject(object));
+        page.addBracketedGroup(createBracketedGroupObject(object));
       } else if (name.equals(CDXMLObj_Curve)) {
-        page.getCurves().add(createSplineObject(object));
+        page.addCurve(createSplineObject(object));
       } else if (name.equals(CDXMLObj_EmbeddedObject)) {
-        page.getEmbeddedObjects().add(createEmbeddedObjectObject(object));
+        page.addEmbeddedObject(createEmbeddedObjectObject(object));
       } else if (name.equals(CDXMLObj_Table)) {
-        page.getTables().add(createTableObject(object));
+        page.addTable(createTableObject(object));
       } else if (name.equals(CDXMLObj_NamedAlternativeGroup)) {
-        page.getNamedAlternativeGroups().add(createNamedAlternativeGroupObject(object));
+        page.addNamedAlternativeGroup(createNamedAlternativeGroupObject(object));
       } else if (name.equals(CDXMLObj_ReactionScheme)) {
-        page.getReactionSchemes().add(createReactionSchemeObject(object));
+        page.addReactionScheme(createReactionSchemeObject(object));
       } else if (name.equals(CDXMLObj_ReactionStep)) {
-        page.getReactionSteps().add(createReactionStepObject(object));
+        page.addReactionStep(createReactionStepObject(object));
       } else if (name.equals(CDXMLObj_Spectrum)) {
-        page.getSpectra().add(createSpectrumObject(object));
+        page.addSpectrum(createSpectrumObject(object));
       } else if (name.equals(CDXMLObj_Sequence)) {
-        page.getSequences().add(createSequenceObject(object));
+        page.addSequence(createSequenceObject(object));
       } else if (name.equals(CDXMLObj_CrossReference)) {
-        page.getCrossReferences().add(createCrossReferenceObject(object));
+        page.addCrossReference(createCrossReferenceObject(object));
       } else if (name.equals(CDXMLObj_Border)) {
-        page.getBorders().add(createBorderObject(object));
+        page.addBorder(createBorderObject(object));
       } else if (name.equals(CDXMLObj_Geometry)) {
-        page.getGeometries().add(createGeometryObject(object));
+        page.addGeometry(createGeometryObject(object));
       } else if (name.equals(CDXMLObj_Constraint)) {
-        page.getConstraints().add(createConstraintObject(object));
+        page.addConstraint(createConstraintObject(object));
       } else if (name.equals(CDXMLObj_TLCPlate)) {
-        page.getTLCPlates().add(createTLCPlateObject(object));
+        page.addTLCPlate(createTLCPlateObject(object));
       } else if (name.equals(CDXMLObj_Splitter)) {
-        page.getSplitters().add(createSplitterObject(object));
+        page.addSplitter(createSplitterObject(object));
       } else if (name.equals(CDXMLObj_ChemicalProperty)) {
-        page.getChemicalProperties().add(createChemicalPropertyObject(object));
+        page.addChemicalProperty(createChemicalPropertyObject(object));
       } else {
 
         // TODO arrow, bioshape
@@ -406,19 +406,19 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Node)) {
-        fragment.getAtoms().add(createNodeObject(object));
+        fragment.addAtom(createNodeObject(object));
       } else if (name.equals(CDXMLObj_Bond)) {
-        fragment.getBonds().add(createBondObject(object));
+        fragment.addBond(createBondObject(object));
       } else if (name.equals(CDXMLObj_Graphic)) {
-        fragment.getGraphics().add(createGraphicObject(object));
+        fragment.addGraphic(createGraphicObject(object));
       } else if (name.equals(CDXMLObj_Curve)) {
-        fragment.getCurves().add(createSplineObject(object));
+        fragment.addCurve(createSplineObject(object));
       } else if (name.equals(CDXMLObj_ObjectTag)) {
-        fragment.getObjectTags().add(createObjectTagObject(object));
+        fragment.addObjectTag(createObjectTagObject(object));
       } else if (name.equals(CDXMLObj_Text)) {
-        fragment.getTexts().add(createTextObject(object));
+        fragment.addText(createTextObject(object));
       } else if (name.equals(CDXMLObj_ColoredMolecularArea)) {
-        fragment.getColoredMolecularAreas().add(createColoredMolecularArea(object));
+        fragment.addColoredMolecularArea(createColoredMolecularArea(object));
       } else {
 
         // regnum
@@ -472,7 +472,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Fragment)) {
-        node.getFragments().add(createFragmentObject(object));
+        node.addFragment(createFragmentObject(object));
       } else if (name.equals(CDXMLObj_Text)) {
         if (node.getText() != null) {
           throw new IOException("Unexpected object");
@@ -480,7 +480,7 @@ public class CDXMLReader {
         node.setText(createTextObject(object));
 
       } else if (name.equals(CDXMLObj_ObjectTag)) {
-        node.getObjectTags().add(createObjectTagObject(object));
+        node.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -634,7 +634,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        bond.getObjectTags().add(createObjectTagObject(object));
+        bond.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -781,27 +781,27 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Group)) {
-        group.getGroups().add(createGroupObject(object));
+        group.addGroup(createGroupObject(object));
       } else if (name.equals(CDXMLObj_Fragment)) {
-        group.getFragments().add(createFragmentObject(object));
+        group.addFragment(createFragmentObject(object));
       } else if (name.equals(CDXMLObj_Text)) {
-        group.getCaptions().add(createTextObject(object));
+        group.addCaption(createTextObject(object));
       } else if (name.equals(CDXMLObj_Graphic)) {
-        group.getGraphics().add(createGraphicObject(object));
+        group.addGraphic(createGraphicObject(object));
       } else if (name.equals(CDXMLObj_Arrow)) {
-        group.getArrows().add(createArrowObject(object));
+        group.addArrow(createArrowObject(object));
       } else if (name.equals(CDXMLObj_Curve)) {
-        group.getCurves().add(createSplineObject(object));
+        group.addCurve(createSplineObject(object));
       } else if (name.equals(CDXMLObj_NamedAlternativeGroup)) {
-        group.getNamedAlternativeGroups().add(createNamedAlternativeGroupObject(object));
+        group.addNamedAlternativeGroup(createNamedAlternativeGroupObject(object));
       } else if (name.equals(CDXMLObj_ReactionStep)) {
-        group.getReactionSteps().add(createReactionStepObject(object));
+        group.addReactionStep(createReactionStepObject(object));
       } else if (name.equals(CDXMLObj_Spectrum)) {
-        group.getSpectra().add(createSpectrumObject(object));
+        group.addSpectrum(createSpectrumObject(object));
       } else if (name.equals(CDXMLObj_EmbeddedObject)) {
-        group.getEmbeddedObjects().add(createEmbeddedObjectObject(object));
+        group.addEmbeddedObject(createEmbeddedObjectObject(object));
       } else if (name.equals(CDXMLObj_ObjectTag)) {
-        group.getObjectTags().add(createObjectTagObject(object));
+        group.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -839,13 +839,13 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        text.getObjectTags().add(createObjectTagObject(object));
+        text.addObjectTag(createObjectTagObject(object));
       } else if (name.equals(CDXMLObj_String)) {
         CDStyledString string = text.getText();
         if (string == null) {
           string = new CDStyledString();
         }
-        string.getChunks().addAll(createStyledString(object).getChunks());
+        string.addAllChunks(createStyledString(object).getChunks());
         text.setText(string);
       } else {
 
@@ -947,7 +947,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        graphic.getObjectTags().add(createObjectTagObject(object));
+        graphic.addObjectTag(createObjectTagObject(object));
       } else if (name.equals(CDXMLObj_Represent)) {
         createRepresent(object, graphic.getRepresents());
       } else {
@@ -1089,7 +1089,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        arrow.getObjectTags().add(createObjectTagObject(object));
+        arrow.addObjectTag(createObjectTagObject(object));
       } else {
         handleMissingObject(object);
       }
@@ -1189,9 +1189,9 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_BracketedGroup)) {
-        bracketedGroup.getBrackets().add(createBracketedGroupObject(object));
+        bracketedGroup.addBracket(createBracketedGroupObject(object));
       } else if (name.equals(CDXMLObj_BracketAttachment)) {
-        bracketedGroup.getBracketAttachments().add(createBracketAttachmentObject(object));
+        bracketedGroup.addBracketAttachment(createBracketAttachmentObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1244,7 +1244,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_CrossingBond)) {
-        bracketAttachment.getCrossingBonds().add(createCrossingBondObject(object));
+        bracketAttachment.addCrossingBond(createCrossingBondObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1351,9 +1351,9 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        plate.getObjectTags().add(createObjectTagObject(object));
+        plate.addObjectTag(createObjectTagObject(object));
       } else if (name.equals(CDXMLObj_TLCLane)) {
-        plate.getLanes().add(createTLCLaneObject(object));
+        plate.addLane(createTLCLaneObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1432,9 +1432,9 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        lane.getObjectTags().add(createObjectTagObject(object));
+        lane.addObjectTag(createObjectTagObject(object));
       } else if (name.equals(CDXMLObj_TLCSpot)) {
-        lane.getSpots().add(createTLCSpotObject(object));
+        lane.addSpot(createTLCSpotObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1470,7 +1470,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        spot.getObjectTags().add(createObjectTagObject(object));
+        spot.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1520,7 +1520,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        constraint.getObjectTags().add(createObjectTagObject(object));
+        constraint.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1589,7 +1589,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        geometry.getObjectTags().add(createObjectTagObject(object));
+        geometry.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1757,7 +1757,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        spectrum.getObjectTags().add(createObjectTagObject(object));
+        spectrum.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1916,7 +1916,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ReactionStep)) {
-        reactionScheme.getSteps().add(createReactionStepObject(object));
+        reactionScheme.addStep(createReactionStepObject(object));
       } else {
 
         handleMissingObject(object);
@@ -1950,13 +1950,13 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Group)) {
-        namedAlternativeGroup.getGroups().add(createGroupObject(object));
+        namedAlternativeGroup.addGroup(createGroupObject(object));
       } else if (name.equals(CDXMLObj_Fragment)) {
-        namedAlternativeGroup.getFragments().add(createFragmentObject(object));
+        namedAlternativeGroup.addFragment(createFragmentObject(object));
       } else if (name.equals(CDXMLObj_Text)) {
-        namedAlternativeGroup.getCaptions().add(createTextObject(object));
+        namedAlternativeGroup.addCaption(createTextObject(object));
       } else if (name.equals(CDXMLObj_ObjectTag)) {
-        namedAlternativeGroup.getObjectTags().add(createObjectTagObject(object));
+        namedAlternativeGroup.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -2013,9 +2013,9 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Page)) {
-        table.getPages().add(createPageObject(object));
+        table.addPage(createPageObject(object));
       } else if (name.equals(CDXMLObj_ObjectTag)) {
-        table.getObjectTags().add(createObjectTagObject(object));
+        table.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -2073,7 +2073,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        embeddedObject.getObjectTags().add(createObjectTagObject(object));
+        embeddedObject.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -2216,7 +2216,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_ObjectTag)) {
-        curve.getObjectTags().add(createObjectTagObject(object));
+        curve.addObjectTag(createObjectTagObject(object));
       } else {
 
         handleMissingObject(object);
@@ -2299,7 +2299,7 @@ public class CDXMLReader {
     for (XMLObject object : root.getObjects()) {
       String name = object.getName();
       if (name.equals(CDXMLObj_Text)) {
-        objectTag.getTexts().add(createTextObject(object));
+        objectTag.addText(createTextObject(object));
       } else {
 
         handleMissingObject(object);
@@ -2505,9 +2505,8 @@ public class CDXMLReader {
     CDColor color = readColorAttribute(object, CDXMLProp_ForegroundColor);
 
     CDStyledString string = new CDStyledString();
-    string
-        .getChunks()
-        .add(new CDStyledString.CDXChunk(font, size, fontType, color, object.getTextsAsString()));
+    string.addChunk(
+        new CDStyledString.CDXChunk(font, size, fontType, color, object.getTextsAsString()));
     return string;
   }
 

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLReader.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLReader.java
@@ -1828,7 +1828,11 @@ public class CDXMLReader {
       List<Double> values = new ArrayList<>();
       for (String part : text.split("\\s+")) {
         if (part.length() > 0) {
-          values.add(Double.parseDouble(part));
+          try {
+            values.add(Double.parseDouble(part));
+          } catch (NumberFormatException e) {
+            logger.warn("Skipping non-numeric spectrum data point \"" + part + "\"", e);
+          }
         }
       }
       double[] array = new double[values.size()];

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLUtils.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLUtils.java
@@ -533,7 +533,13 @@ public class CDXMLUtils {
   public static byte[] convertStringToByteArray(String value) {
     byte[] array = new byte[value.length() / 2];
     for (int offset = 0; offset < value.length(); offset += 2) {
-      array[offset / 2] = (byte) Integer.parseInt(value.substring(offset, offset + 2), 16);
+      String hex = value.substring(offset, offset + 2);
+      try {
+        array[offset / 2] = (byte) Integer.parseInt(hex, 16);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid hexadecimal byte \"" + hex + "\" at offset " + offset, e);
+      }
     }
     return array;
   }
@@ -551,7 +557,12 @@ public class CDXMLUtils {
     List<String> stringList = convertStringToStringList(value);
     List<Integer> list = new ArrayList<>(stringList.size());
     for (String element : stringList) {
-      list.add(Integer.parseInt(element));
+      try {
+        list.add(Integer.parseInt(element));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid integer \"" + element + "\" in list \"" + value + "\"", e);
+      }
     }
     return list;
   }
@@ -581,10 +592,14 @@ public class CDXMLUtils {
   public static CDRectangle convertStringToRectangle(String value) {
     List<String> list = convertStringToStringList(value);
     CDRectangle rectangle = new CDRectangle();
-    rectangle.setLeft(Float.parseFloat(list.get(0)));
-    rectangle.setTop(Float.parseFloat(list.get(1)));
-    rectangle.setRight(Float.parseFloat(list.get(2)));
-    rectangle.setBottom(Float.parseFloat(list.get(3)));
+    try {
+      rectangle.setLeft(Float.parseFloat(list.get(0)));
+      rectangle.setTop(Float.parseFloat(list.get(1)));
+      rectangle.setRight(Float.parseFloat(list.get(2)));
+      rectangle.setBottom(Float.parseFloat(list.get(3)));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid rectangle value \"" + value + "\"", e);
+    }
     return rectangle;
   }
 
@@ -595,8 +610,12 @@ public class CDXMLUtils {
   public static CDPoint2D convertStringToPoint2D(String value) {
     List<String> list = convertStringToStringList(value);
     CDPoint2D point = new CDPoint2D();
-    point.setX(Float.parseFloat(list.get(0)));
-    point.setY(Float.parseFloat(list.get(1)));
+    try {
+      point.setX(Float.parseFloat(list.get(0)));
+      point.setY(Float.parseFloat(list.get(1)));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid 2D point value \"" + value + "\"", e);
+    }
     return point;
   }
 
@@ -615,8 +634,13 @@ public class CDXMLUtils {
     List<CDPoint2D> pointList = new ArrayList<>(count);
     for (int i = 0, offset = 0; i < count; i++, offset += 2) {
       CDPoint2D point = new CDPoint2D();
-      point.setX(Float.parseFloat(list.get(offset)));
-      point.setY(Float.parseFloat(list.get(offset + 1)));
+      try {
+        point.setX(Float.parseFloat(list.get(offset)));
+        point.setY(Float.parseFloat(list.get(offset + 1)));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid 2D point at index " + i + " in \"" + value + "\"", e);
+      }
       pointList.add(point);
     }
     return pointList;
@@ -629,9 +653,13 @@ public class CDXMLUtils {
   public static CDPoint3D convertStringToPoint3D(String value) {
     List<String> list = convertStringToStringList(value);
     CDPoint3D point = new CDPoint3D();
-    point.setX(Float.parseFloat(list.get(0)));
-    point.setY(Float.parseFloat(list.get(1)));
-    point.setZ(Float.parseFloat(list.get(2)));
+    try {
+      point.setX(Float.parseFloat(list.get(0)));
+      point.setY(Float.parseFloat(list.get(1)));
+      point.setZ(Float.parseFloat(list.get(2)));
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid 3D point value \"" + value + "\"", e);
+    }
     return point;
   }
 
@@ -650,9 +678,14 @@ public class CDXMLUtils {
     List<CDPoint3D> pointList = new ArrayList<>(count);
     for (int i = 0, offset = 0; i < count; i++, offset += 3) {
       CDPoint3D point = new CDPoint3D();
-      point.setX(Float.parseFloat(list.get(offset)));
-      point.setY(Float.parseFloat(list.get(offset + 1)));
-      point.setZ(Float.parseFloat(list.get(offset + 2)));
+      try {
+        point.setX(Float.parseFloat(list.get(offset)));
+        point.setY(Float.parseFloat(list.get(offset + 1)));
+        point.setZ(Float.parseFloat(list.get(offset + 2)));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Invalid 3D point at index " + i + " in \"" + value + "\"", e);
+      }
       pointList.add(point);
     }
     return pointList;
@@ -678,7 +711,11 @@ public class CDXMLUtils {
       stringList.remove(0);
     }
     for (String element : stringList) {
-      list.getElements().add(Integer.parseInt(element));
+      try {
+        list.addElement(Integer.parseInt(element));
+      } catch (NumberFormatException e) {
+        logger.warn("Skipping non-integer element in CDElementList: \"" + element + "\"", e);
+      }
     }
     return list;
   }
@@ -702,7 +739,7 @@ public class CDXMLUtils {
       list.setExclusive(true);
       stringList.remove(0);
     }
-    list.getElements().addAll(stringList);
+    list.addAllElements(stringList);
     return list;
   }
 
@@ -745,7 +782,11 @@ public class CDXMLUtils {
     if (value.equals("auto")) {
       return CDSettings.LineHeight_Automatic;
     }
-    return (int) Float.parseFloat(value);
+    try {
+      return (int) Float.parseFloat(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid line height value \"" + value + "\"", e);
+    }
   }
 
   public static String convertObjectRefToString(Object value, Map<Object, Integer> references)
@@ -759,7 +800,13 @@ public class CDXMLUtils {
   @SuppressWarnings("unchecked")
   public static <T> T convertStringToObjectRef(String value, Class<T> clazz, RefManager refManager)
       throws IOException {
-    return refManager.getObjectRef(Integer.parseInt(value), clazz, CDXMLReader.RIGID);
+    final int ref;
+    try {
+      ref = Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw new IOException("Invalid object reference \"" + value + "\"", e);
+    }
+    return refManager.getObjectRef(ref, clazz, CDXMLReader.RIGID);
   }
 
   public static String convertObjectRefList(List<?> value, Map<Object, Integer> references) {

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLWriter.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXMLWriter.java
@@ -2141,6 +2141,8 @@ public class CDXMLWriter {
     attributes.addAttribute("", name, name, CDATA, value);
   }
 
+  // CDXML date serialization is intentionally a no-op (parity with current behavior).
+  @SuppressWarnings("unused")
   private void addAttribute(AttributesImpl attributes, String name, Date value) {
     if (value == null) {
       return;

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXObject.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXObject.java
@@ -22,6 +22,7 @@
 package org.beilstein.chemxtract.cdx.reader;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -80,18 +81,26 @@ public class CDXObject {
   }
 
   public List<CDXObject> getObjects() {
-    return objects;
+    return Collections.unmodifiableList(objects);
   }
 
   public void setObjects(List<CDXObject> objects) {
-    this.objects = objects;
+    this.objects = objects == null ? new ArrayList<>() : new ArrayList<>(objects);
+  }
+
+  public void addObject(CDXObject object) {
+    this.objects.add(object);
   }
 
   public List<CDXProperty> getProperties() {
-    return properties;
+    return Collections.unmodifiableList(properties);
   }
 
   public void setProperties(List<CDXProperty> properties) {
-    this.properties = properties;
+    this.properties = properties == null ? new ArrayList<>() : new ArrayList<>(properties);
+  }
+
+  public void addProperty(CDXProperty property) {
+    this.properties.add(property);
   }
 }

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXProperty.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXProperty.java
@@ -773,7 +773,7 @@ public class CDXProperty {
       elementList.setExclusive(true);
     }
     for (int i = 0; i < length; i += 2) {
-      elementList.getElements().add(CDXUtils.readUInt16(data, i));
+      elementList.addElement(CDXUtils.readUInt16(data, i));
     }
     return elementList;
   }
@@ -791,7 +791,7 @@ public class CDXProperty {
     for (int i = 0; i < count; i++) {
       int stringLength = CDXUtils.readUInt16(data, position);
       CDStyledString string = readStyledString(position + 2, stringLength, fonts, colors);
-      genericList.getElements().add(string.getText());
+      genericList.addElement(string.getText());
       position += 4 + string.getChunks().size() * 10 + string.getText().length();
     }
     return genericList;
@@ -843,15 +843,13 @@ public class CDXProperty {
           charSetName = "windows-1252";
         }
         try {
-          string
-              .getChunks()
-              .add(
-                  new CDStyledString.CDXChunk(
-                      fontStyles[i].getFont(),
-                      fontStyles[i].getSize(),
-                      fontStyles[i].getFontType(),
-                      fontStyles[i].getColor(),
-                      new String(bytes, charSetName)));
+          string.addChunk(
+              new CDStyledString.CDXChunk(
+                  fontStyles[i].getFont(),
+                  fontStyles[i].getSize(),
+                  fontStyles[i].getFontType(),
+                  fontStyles[i].getColor(),
+                  new String(bytes, charSetName)));
         } catch (UnsupportedEncodingException exception) {
           logger.warn("Found unsupported encoding; text chunk discarded.", exception);
         }
@@ -871,25 +869,21 @@ public class CDXProperty {
           charSetName = "windows-1252";
         }
         try {
-          string
-              .getChunks()
-              .add(
-                  new CDStyledString.CDXChunk(
-                      fontStyles[last].getFont(),
-                      fontStyles[last].getSize(),
-                      fontStyles[last].getFontType(),
-                      fontStyles[last].getColor(),
-                      new String(bytes, charSetName)));
+          string.addChunk(
+              new CDStyledString.CDXChunk(
+                  fontStyles[last].getFont(),
+                  fontStyles[last].getSize(),
+                  fontStyles[last].getFontType(),
+                  fontStyles[last].getColor(),
+                  new String(bytes, charSetName)));
         } catch (UnsupportedEncodingException exception) {
           logger.warn("Found unsupported encoding; text chunk discarded.", exception);
         }
       }
     } else {
-      string
-          .getChunks()
-          .add(
-              new CDStyledString.CDXChunk(
-                  fonts.get(0), 12, new CDFontFace(), colors.get(0), new String(text)));
+      string.addChunk(
+          new CDStyledString.CDXChunk(
+              fonts.get(0), 12, new CDFontFace(), colors.get(0), new String(text)));
     }
     return string;
   }

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXProperty.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXProperty.java
@@ -362,7 +362,6 @@ public class CDXProperty {
     return map;
   }
 
-  @SuppressWarnings("deprecation")
   public Date getDataAsDate() throws IOException {
     checkPropSize(14);
     int year = CDXUtils.readInt16(data, 0);
@@ -371,7 +370,9 @@ public class CDXProperty {
     int hour = CDXUtils.readInt16(data, 6);
     int minute = CDXUtils.readInt16(data, 8);
     int second = CDXUtils.readInt16(data, 10);
-    return new Date(year, month, day, hour, minute, second);
+    // Match the legacy Date(year, month, day, h, m, s) semantics: year is offset from 1900,
+    // month is 0-based — both already true for the values written by CDX.
+    return new GregorianCalendar(year + 1900, month, day, hour, minute, second).getTime();
   }
 
   public String getDataAsString() {

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXReader.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXReader.java
@@ -119,7 +119,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Page:
-          document.getPages().add(createPageObject(object));
+          document.addPage(createPageObject(object));
           break;
         case CDXObj_TemplateGrid:
           if (document.getTemplateGrid() != null) {
@@ -353,68 +353,68 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Group:
-          page.getGroups().add(createGroupObject(object));
+          page.addGroup(createGroupObject(object));
           break;
         case CDXObj_Fragment:
-          page.getFragments().add(createFragmentObject(object));
+          page.addFragment(createFragmentObject(object));
           break;
         case CDXObj_Text:
-          page.getTexts().add(createTextObject(object));
+          page.addText(createTextObject(object));
           break;
         case CDXObj_Graphic:
-          page.getGraphics().add(createGraphicObject(object));
+          page.addGraphic(createGraphicObject(object));
           break;
         case CDXObj_BracketedGroup:
-          page.getBracketedGroups().add(createBracketedGroupObject(object));
+          page.addBracketedGroup(createBracketedGroupObject(object));
           break;
         case CDXObj_Curve:
-          page.getCurves().add(createSplineObject(object));
+          page.addCurve(createSplineObject(object));
           break;
         case CDXObj_EmbeddedObject:
-          page.getEmbeddedObjects().add(createEmbeddedObjectObject(object));
+          page.addEmbeddedObject(createEmbeddedObjectObject(object));
           break;
         case CDXObj_Table:
-          page.getTables().add(createTableObject(object));
+          page.addTable(createTableObject(object));
           break;
         case CDXObj_NamedAlternativeGroup:
-          page.getNamedAlternativeGroups().add(createNamedAlternativeGroupObject(object));
+          page.addNamedAlternativeGroup(createNamedAlternativeGroupObject(object));
           break;
         case CDXObj_ReactionScheme:
-          page.getReactionSchemes().add(createReactionSchemeObject(object));
+          page.addReactionScheme(createReactionSchemeObject(object));
           break;
         case CDXObj_ReactionStep:
-          page.getReactionSteps().add(createReactionStepObject(object));
+          page.addReactionStep(createReactionStepObject(object));
           break;
         case CDXObj_Spectrum:
-          page.getSpectra().add(createSpectrumObject(object));
+          page.addSpectrum(createSpectrumObject(object));
           break;
         case CDXObj_Sequence:
-          page.getSequences().add(createSequenceObject(object));
+          page.addSequence(createSequenceObject(object));
           break;
         case CDXObj_CrossReference:
-          page.getCrossReferences().add(createCrossReferenceObject(object));
+          page.addCrossReference(createCrossReferenceObject(object));
           break;
         case CDXObj_Border:
-          page.getBorders().add(createBorderObject(object));
+          page.addBorder(createBorderObject(object));
           break;
         case CDXObj_Geometry:
-          page.getGeometries().add(createGeometryObject(object));
+          page.addGeometry(createGeometryObject(object));
           break;
         case CDXObj_Constraint:
-          page.getConstraints().add(createConstraintObject(object));
+          page.addConstraint(createConstraintObject(object));
           break;
         case CDXObj_TLCPlate:
-          page.getTLCPlates().add(createTLCPlateObject(object));
+          page.addTLCPlate(createTLCPlateObject(object));
           break;
         case CDXObj_Splitter:
-          page.getSplitters().add(createSplitterObject(object));
+          page.addSplitter(createSplitterObject(object));
           break;
         case CDXObj_ChemicalProperty:
-          page.getChemicalProperties().add(createChemicalPropertyObject(object));
+          page.addChemicalProperty(createChemicalPropertyObject(object));
           break;
 
         case CDXObj_Arrow:
-          page.getArrows().add(createArrowObject(object));
+          page.addArrow(createArrowObject(object));
           break;
 
         default:
@@ -496,29 +496,29 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Node:
-          fragment.getAtoms().add(createNodeObject(object));
+          fragment.addAtom(createNodeObject(object));
           break;
         case CDXObj_Bond:
-          fragment.getBonds().add(createBondObject(object));
+          fragment.addBond(createBondObject(object));
           break;
         case CDXObj_Graphic:
-          fragment.getGraphics().add(createGraphicObject(object));
+          fragment.addGraphic(createGraphicObject(object));
           break;
         case CDXObj_Curve:
-          fragment.getCurves().add(createSplineObject(object));
+          fragment.addCurve(createSplineObject(object));
           break;
         case CDXObj_ObjectTag:
-          fragment.getObjectTags().add(createObjectTagObject(object));
+          fragment.addObjectTag(createObjectTagObject(object));
           break;
 
         case CDXObj_Text:
-          fragment.getTexts().add(createTextObject(object));
+          fragment.addText(createTextObject(object));
           break;
         case CDXObj_Arrow:
-          fragment.getArrows().add(createArrowObject(object));
+          fragment.addArrow(createArrowObject(object));
           break;
         case CDXObj_ColoredMolecularArea:
-          fragment.getColoredMolecularAreas().add(createColoredMolecularArea(object));
+          fragment.addColoredMolecularArea(createColoredMolecularArea(object));
           break;
 
         default:
@@ -573,7 +573,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Fragment:
-          node.getFragments().add(createFragmentObject(object));
+          node.addFragment(createFragmentObject(object));
           break;
         case CDXObj_Text:
           if (node.getText() != null) {
@@ -582,7 +582,7 @@ public class CDXReader {
           node.setText(createTextObject(object));
           break;
         case CDXObj_ObjectTag:
-          node.getObjectTags().add(createObjectTagObject(object));
+          node.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -794,7 +794,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          bond.getObjectTags().add(createObjectTagObject(object));
+          bond.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -978,38 +978,38 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Group:
-          group.getGroups().add(createGroupObject(object));
+          group.addGroup(createGroupObject(object));
           break;
         case CDXObj_Fragment:
-          group.getFragments().add(createFragmentObject(object));
+          group.addFragment(createFragmentObject(object));
           break;
         case CDXObj_Text:
-          group.getCaptions().add(createTextObject(object));
+          group.addCaption(createTextObject(object));
           break;
         case CDXObj_Graphic:
-          group.getGraphics().add(createGraphicObject(object));
+          group.addGraphic(createGraphicObject(object));
           break;
         case CDXObj_Curve:
-          group.getCurves().add(createSplineObject(object));
+          group.addCurve(createSplineObject(object));
           break;
         case CDXObj_NamedAlternativeGroup:
-          group.getNamedAlternativeGroups().add(createNamedAlternativeGroupObject(object));
+          group.addNamedAlternativeGroup(createNamedAlternativeGroupObject(object));
           break;
         case CDXObj_ReactionStep:
-          group.getReactionSteps().add(createReactionStepObject(object));
+          group.addReactionStep(createReactionStepObject(object));
           break;
         case CDXObj_Spectrum:
-          group.getSpectra().add(createSpectrumObject(object));
+          group.addSpectrum(createSpectrumObject(object));
           break;
         case CDXObj_EmbeddedObject:
-          group.getEmbeddedObjects().add(createEmbeddedObjectObject(object));
+          group.addEmbeddedObject(createEmbeddedObjectObject(object));
           break;
         case CDXObj_ObjectTag:
-          group.getObjectTags().add(createObjectTagObject(object));
+          group.addObjectTag(createObjectTagObject(object));
           break;
 
         case CDXObj_Arrow:
-          group.getArrows().add(createArrowObject(object));
+          group.addArrow(createArrowObject(object));
           break;
 
         default:
@@ -1050,7 +1050,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          text.getObjectTags().add(createObjectTagObject(object));
+          text.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -1180,7 +1180,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          graphic.getObjectTags().add(createObjectTagObject(object));
+          graphic.addObjectTag(createObjectTagObject(object));
           break;
         default:
           handleMissingTag(object);
@@ -1363,7 +1363,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          arrow.getObjectTags().add(createObjectTagObject(object));
+          arrow.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -1501,10 +1501,10 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_BracketedGroup:
-          bracketedGroup.getBrackets().add(createBracketedGroupObject(object));
+          bracketedGroup.addBracket(createBracketedGroupObject(object));
           break;
         case CDXObj_BracketAttachment:
-          bracketedGroup.getBracketAttachments().add(createBracketAttachmentObject(object));
+          bracketedGroup.addBracketAttachment(createBracketAttachmentObject(object));
           break;
 
         default:
@@ -1561,7 +1561,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_CrossingBond:
-          bracketAttachment.getCrossingBonds().add(createCrossingBondObject(object));
+          bracketAttachment.addCrossingBond(createCrossingBondObject(object));
           break;
 
         default:
@@ -1673,10 +1673,10 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          plate.getObjectTags().add(createObjectTagObject(object));
+          plate.addObjectTag(createObjectTagObject(object));
           break;
         case CDXObj_TLCLane:
-          plate.getLanes().add(createTLCLaneObject(object));
+          plate.addLane(createTLCLaneObject(object));
           break;
 
         default:
@@ -1771,10 +1771,10 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          lane.getObjectTags().add(createObjectTagObject(object));
+          lane.addObjectTag(createObjectTagObject(object));
           break;
         case CDXObj_TLCSpot:
-          lane.getSpots().add(createTLCSpotObject(object));
+          lane.addSpot(createTLCSpotObject(object));
           break;
 
         default:
@@ -1812,7 +1812,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          spot.getObjectTags().add(createObjectTagObject(object));
+          spot.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -1871,7 +1871,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          constraint.getObjectTags().add(createObjectTagObject(object));
+          constraint.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -1951,7 +1951,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          geometry.getObjectTags().add(createObjectTagObject(object));
+          geometry.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -2142,7 +2142,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          spectrum.getObjectTags().add(createObjectTagObject(object));
+          spectrum.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -2312,7 +2312,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ReactionStep:
-          reactionScheme.getSteps().add(createReactionStepObject(object));
+          reactionScheme.addStep(createReactionStepObject(object));
           break;
 
         default:
@@ -2345,16 +2345,16 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Group:
-          namedAlternativeGroup.getGroups().add(createGroupObject(object));
+          namedAlternativeGroup.addGroup(createGroupObject(object));
           break;
         case CDXObj_Fragment:
-          namedAlternativeGroup.getFragments().add(createFragmentObject(object));
+          namedAlternativeGroup.addFragment(createFragmentObject(object));
           break;
         case CDXObj_Text:
-          namedAlternativeGroup.getCaptions().add(createTextObject(object));
+          namedAlternativeGroup.addCaption(createTextObject(object));
           break;
         case CDXObj_ObjectTag:
-          namedAlternativeGroup.getObjectTags().add(createObjectTagObject(object));
+          namedAlternativeGroup.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -2421,10 +2421,10 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Page:
-          table.getPages().add(createPageObject(object));
+          table.addPage(createPageObject(object));
           break;
         case CDXObj_ObjectTag:
-          table.getObjectTags().add(createObjectTagObject(object));
+          table.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -2492,7 +2492,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          picture.getObjectTags().add(createObjectTagObject(object));
+          picture.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -2642,7 +2642,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_ObjectTag:
-          spline.getObjectTags().add(createObjectTagObject(object));
+          spline.addObjectTag(createObjectTagObject(object));
           break;
 
         default:
@@ -2740,7 +2740,7 @@ public class CDXReader {
     for (CDXObject object : root.getObjects()) {
       switch (object.getTag()) {
         case CDXObj_Text:
-          objectTag.getTexts().add(createTextObject(object));
+          objectTag.addText(createTextObject(object));
           break;
 
         default:

--- a/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXUtils.java
+++ b/src/main/java/org/beilstein/chemxtract/cdx/reader/CDXUtils.java
@@ -124,10 +124,10 @@ public class CDXUtils {
       } else if (tag >= CDXTag_Object) {
         CDXObject object2 = readCDXObject(tag, bytes, position);
         object2.setTag(tag);
-        object.getObjects().add(object2);
+        object.addObject(object2);
       } else {
         CDXProperty property = readCDXProperty(tag, bytes, position);
-        object.getProperties().add(property);
+        object.addProperty(property);
       }
     }
     return object;

--- a/src/main/java/org/beilstein/chemxtract/io/XMLEntityCatalog.java
+++ b/src/main/java/org/beilstein/chemxtract/io/XMLEntityCatalog.java
@@ -90,7 +90,7 @@ public class XMLEntityCatalog implements EntityResolver {
 
     // resolve URL to input stream
     if (url != null) {
-      InputStream in = getClass().getClassLoader().getResourceAsStream(url);
+      InputStream in = XMLEntityCatalog.class.getClassLoader().getResourceAsStream(url);
       if (in == null) {
         logger.debug("No resource found for url " + url);
         File file = new File(url);
@@ -101,14 +101,23 @@ public class XMLEntityCatalog implements EntityResolver {
         in = new FileInputStream(file);
         systemId = file.toURI().toString();
       } else {
-        systemId = getClass().getClassLoader().getResource(url).toString();
+        systemId = XMLEntityCatalog.class.getClassLoader().getResource(url).toString();
       }
 
-      // create input source
-      InputSource inputSource = new InputSource(in);
-      inputSource.setPublicId(publicId);
-      inputSource.setSystemId(systemId);
-      return inputSource;
+      // Hand ownership of the stream to InputSource; close it ourselves if construction fails.
+      try {
+        InputSource inputSource = new InputSource(in);
+        inputSource.setPublicId(publicId);
+        inputSource.setSystemId(systemId);
+        return inputSource;
+      } catch (RuntimeException e) {
+        try {
+          in.close();
+        } catch (IOException ignored) {
+          // best-effort close on the error path
+        }
+        throw e;
+      }
     }
     logger.warn("No entry found for public id:" + publicId + " and system id:" + systemId);
     return null;

--- a/src/main/java/org/beilstein/chemxtract/io/XMLObject.java
+++ b/src/main/java/org/beilstein/chemxtract/io/XMLObject.java
@@ -133,7 +133,7 @@ public class XMLObject {
    * @return Text elements
    */
   public List<String> getTexts() {
-    return texts;
+    return Collections.unmodifiableList(texts);
   }
 
   /**
@@ -142,7 +142,16 @@ public class XMLObject {
    * @param texts Text elements.
    */
   public void setTexts(List<String> texts) {
-    this.texts = texts;
+    this.texts = texts == null ? new ArrayList<>() : new ArrayList<>(texts);
+  }
+
+  /**
+   * Adds a text element to the XML element.
+   *
+   * @param text Text element
+   */
+  public void addText(String text) {
+    this.texts.add(text);
   }
 
   /**
@@ -170,7 +179,7 @@ public class XMLObject {
    * @return Element attributes
    */
   public Map<String, String> getAttributes() {
-    return attributes;
+    return Collections.unmodifiableMap(attributes);
   }
 
   /**
@@ -179,7 +188,7 @@ public class XMLObject {
    * @param attributes Element attributes
    */
   public void setAttributes(Map<String, String> attributes) {
-    this.attributes = attributes;
+    this.attributes = attributes == null ? new LinkedHashMap<>() : new LinkedHashMap<>(attributes);
   }
 
   /**
@@ -188,7 +197,7 @@ public class XMLObject {
    * @return Child elements
    */
   public List<XMLObject> getObjects() {
-    return objects;
+    return Collections.unmodifiableList(objects);
   }
 
   /**
@@ -197,7 +206,7 @@ public class XMLObject {
    * @param objects Child elements
    */
   public void setObjects(List<XMLObject> objects) {
-    this.objects = objects;
+    this.objects = objects == null ? new ArrayList<>() : new ArrayList<>(objects);
   }
 
   /**

--- a/src/main/java/org/beilstein/chemxtract/io/XMLReaderHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/io/XMLReaderHandler.java
@@ -73,7 +73,7 @@ public class XMLReaderHandler implements ContentHandler {
     }
     if (!stack.isEmpty()) {
       XMLObject object = stack.peek();
-      object.getTexts().add(sb.length() > 0 ? sb.toString() : null);
+      object.addText(sb.length() > 0 ? sb.toString() : null);
     }
 
     XMLObject object = new XMLObject();
@@ -85,11 +85,11 @@ public class XMLReaderHandler implements ContentHandler {
     for (int i = 0; i < atts.getLength(); i++) {
       // remove empty attributes
       if (atts.getValue(i) != null && atts.getValue(i).length() > 0) {
-        object.getAttributes().put(atts.getLocalName(i), atts.getValue(i));
+        object.setAttribute(atts.getLocalName(i), atts.getValue(i));
       }
     }
     if (!stack.isEmpty()) {
-      stack.peek().getObjects().add(object);
+      stack.peek().addObject(object);
     }
     stack.push(object);
 
@@ -118,7 +118,7 @@ public class XMLReaderHandler implements ContentHandler {
       setRoot(object);
     }
 
-    object.getTexts().add(sb.length() > 0 ? sb.toString() : null);
+    object.addText(sb.length() > 0 ? sb.toString() : null);
     sb = new StringBuilder();
   }
 

--- a/src/main/java/org/beilstein/chemxtract/lookups/SMILESLookupReader.java
+++ b/src/main/java/org/beilstein/chemxtract/lookups/SMILESLookupReader.java
@@ -55,7 +55,7 @@ public class SMILESLookupReader {
    * @throws IOException if file could not be imported
    */
   public Map<String, String> loadSmilesLookup(String path, int initialSize) throws IOException {
-    try (InputStream in = this.getClass().getResourceAsStream(path)) {
+    try (InputStream in = SMILESLookupReader.class.getResourceAsStream(path)) {
       if (in != null) return this.loadAbbreviations(in, initialSize);
       File file = new File(path);
       if (file.exists() && file.canRead())

--- a/src/main/java/org/beilstein/chemxtract/lookups/UnwantedAbbreviations.java
+++ b/src/main/java/org/beilstein/chemxtract/lookups/UnwantedAbbreviations.java
@@ -71,12 +71,14 @@ public class UnwantedAbbreviations {
     if (in == null) {
       throw new IOException("UnwantedAbbreviations.txt not found on classpath");
     }
-    BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      line = line.trim();
-      if (!line.isBlank()) {
-        words.add(line);
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (!line.isBlank()) {
+          words.add(line);
+        }
       }
     }
     return Collections.unmodifiableSet(words);

--- a/src/main/java/org/beilstein/chemxtract/lookups/UnwantedWords.java
+++ b/src/main/java/org/beilstein/chemxtract/lookups/UnwantedWords.java
@@ -88,12 +88,14 @@ public class UnwantedWords {
     if (in == null) {
       throw new IOException("unwantedWords.txt not found on classpath");
     }
-    BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
-    String line;
-    while ((line = reader.readLine()) != null) {
-      line = line.trim();
-      if (!line.isBlank()) {
-        words.add(line);
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        line = line.trim();
+        if (!line.isBlank()) {
+          words.add(line);
+        }
       }
     }
     return Collections.unmodifiableSet(words);

--- a/src/main/java/org/beilstein/chemxtract/model/BCXSubstance.java
+++ b/src/main/java/org/beilstein/chemxtract/model/BCXSubstance.java
@@ -193,4 +193,15 @@ public class BCXSubstance implements Serializable {
   public void setAtomContainer(IAtomContainer atomContainer) {
     this.atomContainer = atomContainer;
   }
+
+  @Override
+  public String toString() {
+    return "BCXSubstance [inchiKey="
+        + inchiKey
+        + ", smiles="
+        + smiles
+        + ", molecularFormula="
+        + molecularFormula
+        + "]";
+  }
 }

--- a/src/main/java/org/beilstein/chemxtract/model/BCXSubstanceOccurrence.java
+++ b/src/main/java/org/beilstein/chemxtract/model/BCXSubstanceOccurrence.java
@@ -121,4 +121,17 @@ public class BCXSubstanceOccurrence implements Serializable {
     }
     return true;
   }
+
+  @Override
+  public String toString() {
+    return "BCXSubstanceOccurrence [cdxTop="
+        + cdxTop
+        + ", cdxLeft="
+        + cdxLeft
+        + ", cdxBottom="
+        + cdxBottom
+        + ", cdxRight="
+        + cdxRight
+        + "]";
+  }
 }

--- a/src/main/java/org/beilstein/chemxtract/utils/SgroupHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/SgroupHandler.java
@@ -106,11 +106,11 @@ public class SgroupHandler {
         i < repeatCount - 1;
         i++) { // repeat count -1, as the multiple group already exists once
       CDAtom atom2 = new CDAtom(atom1);
-      fragment.getAtoms().add(atom2);
+      fragment.addAtom(atom2);
       CDBond newBond = new CDBond(crossingBond);
       newBond.setBegin(atom1);
       newBond.setEnd(atom2);
-      fragment.getBonds().add(newBond);
+      fragment.addBond(newBond);
       atom1 = atom2;
       if (i == repeatCount - 2) {
         if (crossingBond.getBegin().equals(atom)) crossingBond.setBegin(atom2);
@@ -158,9 +158,9 @@ public class SgroupHandler {
         copyBond.setBegin(copyBegin);
         copyBond.setEnd(copyEnd);
 
-        fragment.getBonds().add(copyBond);
+        fragment.addBond(copyBond);
       }
-      fragment.getAtoms().addAll(atomMap.values());
+      fragment.addAllAtoms(atomMap.values());
 
       // Reconnect internal multiple group if the bracket has attachments.
       // Bracket must have an even number of crossing bonds, i.e. zero or two.
@@ -207,6 +207,6 @@ public class SgroupHandler {
     copyLastBond.setEnd(firstNonMultipleGroupAtom);
 
     // Add the new bond to the fragment
-    fragment.getBonds().add(copyLastBond);
+    fragment.addBond(copyLastBond);
   }
 }

--- a/src/main/java/org/beilstein/chemxtract/visitor/BondVisitor.java
+++ b/src/main/java/org/beilstein/chemxtract/visitor/BondVisitor.java
@@ -95,7 +95,9 @@ public class BondVisitor extends CDVisitor {
                   .orElseThrow(
                       () ->
                           new IllegalArgumentException(
-                              "Missing external connection point in fragment: " + fragment));
+                              "Missing external connection point in fragment with "
+                                  + fragment.getAtoms().size()
+                                  + " atoms"));
 
           CDAtom conAtom = resolveConnectionAtom(fragment, extCon);
           if (!bond.getBegin().getFragments().isEmpty()) bond.setBegin(conAtom);
@@ -174,7 +176,9 @@ public class BondVisitor extends CDVisitor {
             .orElseThrow(
                 () ->
                     new IllegalArgumentException(
-                        "No bond connected to external atom: " + external));
+                        "No bond connected to external atom (atomNumber="
+                            + external.getAtomNumber()
+                            + ")"));
     return external.equals(exBond.getBegin()) ? exBond.getEnd() : exBond.getBegin();
   }
 

--- a/src/test/java/org/beilstein/chemxtract/cdx/CDXVisitorTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/CDXVisitorTest.java
@@ -53,7 +53,7 @@ public class CDXVisitorTest extends CDVisitor {
   public void testVisitor() throws IOException {
 
     String fileName = "test_fixture.cdxml";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = CDXVisitorTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertThat(in).isNotNull();
 
     CDDocument document = CDXMLReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/cdx/reader/CDXMLReaderTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/reader/CDXMLReaderTest.java
@@ -49,7 +49,7 @@ public class CDXMLReaderTest {
   @Test
   public void testReadCDXML() throws IOException {
     String fileName = "test_fixture.cdxml";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = CDXMLReaderTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXMLReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/cdx/reader/CDXMLWriterTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/reader/CDXMLWriterTest.java
@@ -50,7 +50,7 @@ public class CDXMLWriterTest {
   @Test
   public void testWriteCDXML() throws IOException {
     String fileName = "test_fixture.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = CDXMLWriterTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/cdx/reader/CDXReaderTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/reader/CDXReaderTest.java
@@ -48,7 +48,7 @@ public class CDXReaderTest {
   @Test
   public void testReadCDX() throws Exception {
     String fileName = "test_fixture.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = CDXReaderTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/cdx/reader/ColoredMolecularAreaTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/reader/ColoredMolecularAreaTest.java
@@ -43,7 +43,7 @@ public class ColoredMolecularAreaTest {
   public void testColoredMolecularArea() throws Exception {
 
     String fileName = "colored_molecular_area.cdxml";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = ColoredMolecularAreaTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXMLReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/cdx/reader/RingTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/reader/RingTest.java
@@ -47,7 +47,7 @@ public class RingTest {
   @Test
   public void testRingsCDXML() throws IOException {
     String fileName = "testcase-ringe-simple.cdxml";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = RingTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXMLReader.readDocument(in);
@@ -84,7 +84,7 @@ public class RingTest {
   @Test
   public void testRingsCDX() throws IOException {
     String fileName = "testcase-ringe-simple.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = RingTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/ExtractionTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/ExtractionTest.java
@@ -140,7 +140,7 @@ public class ExtractionTest {
 
     ReactionXtractor xtractor = new ReactionXtractor(SilentChemObjectBuilder.getInstance());
     BCXReactionInfo reactionInfo = new BCXReactionInfo();
-    List<BCXReaction> reactions = xtractor.xtract(document, reactionInfo);
+    xtractor.xtract(document, reactionInfo);
 
     assertThat(reactionInfo.getNoReactionSteps()).isEqualTo(4);
     assertThat(reactionInfo.getNoValidReactions()).isEqualTo(3);

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/ExtractionTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/ExtractionTest.java
@@ -60,7 +60,7 @@ public class ExtractionTest {
   @Test
   public void testExtractSubstances() throws IOException {
     String fileName = "test_fixture.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = ExtractionTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);
@@ -97,7 +97,7 @@ public class ExtractionTest {
   @Test
   public void testExtractReactions() throws IOException {
     String fileName = "test_fixture.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = ExtractionTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);
@@ -132,7 +132,7 @@ public class ExtractionTest {
   @Test
   public void testBCXReactionInfo() throws IOException {
     String fileName = "test_fixture.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = ExtractionTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/IntegrationTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/IntegrationTest.java
@@ -37,7 +37,8 @@ public class IntegrationTest {
   @Test
   public void E_1_Bromo_1_2_dichloroetheneTest() throws IOException {
     InputStream in =
-        IntegrationTest.class.getResourceAsStream("/integrationTests/(E)-1-Bromo-1,2-dichloroethene.cdx");
+        IntegrationTest.class.getResourceAsStream(
+            "/integrationTests/(E)-1-Bromo-1,2-dichloroethene.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -57,7 +58,8 @@ public class IntegrationTest {
   @Test
   public void Z_1_Bromo_1_2_dichloroetheneTest() throws IOException {
     InputStream in =
-        IntegrationTest.class.getResourceAsStream("/integrationTests/(Z)-1-Bromo-1,2-dichloroethene.cdx");
+        IntegrationTest.class.getResourceAsStream(
+            "/integrationTests/(Z)-1-Bromo-1,2-dichloroethene.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -76,7 +78,8 @@ public class IntegrationTest {
 
   @Test
   public void E_Z_either_butene_IUPACTest() throws IOException {
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/E_Z_either_butene.cdx");
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/E_Z_either_butene.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -178,7 +181,8 @@ public class IntegrationTest {
 
   @Test
   public void dLacticAcidStereoTest() throws IOException {
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/D-lactic-acid.cdx");
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/D-lactic-acid.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -201,7 +205,8 @@ public class IntegrationTest {
 
   @Test
   public void lLacticAcidStereoTest() throws IOException {
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/L-lactic-acid.cdx");
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/L-lactic-acid.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -247,7 +252,8 @@ public class IntegrationTest {
   @Test
   public void sugarStereoTest() throws IOException {
     String fileName = "wavy_sugars.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -265,7 +271,8 @@ public class IntegrationTest {
   @Test
   public void sugar_bond_up_SRSSR_Test() throws IOException {
     String fileName = "bond_up_SRSSR.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -278,7 +285,8 @@ public class IntegrationTest {
   @Test
   public void sugarr_bond_down_SRRSR_Test() throws IOException {
     String fileName = "bond_down_SRRSR.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -291,7 +299,8 @@ public class IntegrationTest {
   @Test
   public void sugarr_bond_halfdown_SRRS_Test() throws IOException {
     String fileName = "bond_halfdown_SRRS.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -321,7 +330,8 @@ public class IntegrationTest {
   @Test
   public void multiple_groups_Test() throws IOException {
     String fileName = "multiple_groups.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -349,7 +359,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupsTest() throws Exception {
     String fileName = "multipleGroups.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -363,7 +374,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupNonaneMUL2Test() throws Exception {
     String fileName = "nonane_MUL2.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -376,7 +388,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupDimethylOctanceMUL2Test() throws Exception {
     String fileName = "dimethyloctane_MUL2.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -389,7 +402,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupDimethylStyreneMUL5Test() throws Exception {
     String fileName = "Sgroups_MultipleGroup 01.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -403,7 +417,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupTetramethylnonaneMUL2Test() throws Exception {
     String fileName = "tetramethylnonane_MUL2.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -416,7 +431,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupDecamethylpentadecane_MUL5Test() throws Exception {
     String fileName = "decamethylpentadecane_MUL5.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -429,7 +445,8 @@ public class IntegrationTest {
   @Test
   public void multipleGroupTrimethylnonane_MUL3Test() throws Exception {
     String fileName = "trimethylnonane_MUL3.cdx";
-    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in =
+        IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/IntegrationTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/IntegrationTest.java
@@ -37,7 +37,7 @@ public class IntegrationTest {
   @Test
   public void E_1_Bromo_1_2_dichloroetheneTest() throws IOException {
     InputStream in =
-        this.getClass().getResourceAsStream("/integrationTests/(E)-1-Bromo-1,2-dichloroethene.cdx");
+        IntegrationTest.class.getResourceAsStream("/integrationTests/(E)-1-Bromo-1,2-dichloroethene.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -57,7 +57,7 @@ public class IntegrationTest {
   @Test
   public void Z_1_Bromo_1_2_dichloroetheneTest() throws IOException {
     InputStream in =
-        this.getClass().getResourceAsStream("/integrationTests/(Z)-1-Bromo-1,2-dichloroethene.cdx");
+        IntegrationTest.class.getResourceAsStream("/integrationTests/(Z)-1-Bromo-1,2-dichloroethene.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -76,7 +76,7 @@ public class IntegrationTest {
 
   @Test
   public void E_Z_either_butene_IUPACTest() throws IOException {
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/E_Z_either_butene.cdx");
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/E_Z_either_butene.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -96,7 +96,7 @@ public class IntegrationTest {
   @Test
   public void S_laballenic_acidTest() throws IOException {
     InputStream in =
-        this.getClass().getResourceAsStream("/integrationTests/(S)-laballenic acid.cdx");
+        IntegrationTest.class.getResourceAsStream("/integrationTests/(S)-laballenic acid.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -120,7 +120,7 @@ public class IntegrationTest {
   @Test
   public void R_laballenic_acidTest() throws IOException {
     InputStream in =
-        this.getClass().getResourceAsStream("/integrationTests/(R)-laballenic acid.cdx");
+        IntegrationTest.class.getResourceAsStream("/integrationTests/(R)-laballenic acid.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -142,7 +142,7 @@ public class IntegrationTest {
   @Test
   public void testStructureWithAmbiguousStereo() throws IOException {
     String fileName = "ambiguousStereo.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -157,7 +157,7 @@ public class IntegrationTest {
 
   @Test
   public void getInChITest_1() throws IOException {
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/stereo_bug.cdx");
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/stereo_bug.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -178,7 +178,7 @@ public class IntegrationTest {
 
   @Test
   public void dLacticAcidStereoTest() throws IOException {
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/D-lactic-acid.cdx");
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/D-lactic-acid.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -201,7 +201,7 @@ public class IntegrationTest {
 
   @Test
   public void lLacticAcidStereoTest() throws IOException {
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/L-lactic-acid.cdx");
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/L-lactic-acid.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -225,7 +225,7 @@ public class IntegrationTest {
   @Test
   public void isotopesTest() throws IOException {
     InputStream in =
-        this.getClass().getResourceAsStream("/integrationTests/Isotopes-H-D-T-C-O.cdx");
+        IntegrationTest.class.getResourceAsStream("/integrationTests/Isotopes-H-D-T-C-O.cdx");
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -247,7 +247,7 @@ public class IntegrationTest {
   @Test
   public void sugarStereoTest() throws IOException {
     String fileName = "wavy_sugars.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -265,7 +265,7 @@ public class IntegrationTest {
   @Test
   public void sugar_bond_up_SRSSR_Test() throws IOException {
     String fileName = "bond_up_SRSSR.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -278,7 +278,7 @@ public class IntegrationTest {
   @Test
   public void sugarr_bond_down_SRRSR_Test() throws IOException {
     String fileName = "bond_down_SRRSR.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -291,7 +291,7 @@ public class IntegrationTest {
   @Test
   public void sugarr_bond_halfdown_SRRS_Test() throws IOException {
     String fileName = "bond_halfdown_SRRS.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sugars/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sugars/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -304,7 +304,7 @@ public class IntegrationTest {
   @Test
   public void radicalTest() throws Exception {
     String fileName = "radical.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -321,7 +321,7 @@ public class IntegrationTest {
   @Test
   public void multiple_groups_Test() throws IOException {
     String fileName = "multiple_groups.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -349,7 +349,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupsTest() throws Exception {
     String fileName = "multipleGroups.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -363,7 +363,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupNonaneMUL2Test() throws Exception {
     String fileName = "nonane_MUL2.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -376,7 +376,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupDimethylOctanceMUL2Test() throws Exception {
     String fileName = "dimethyloctane_MUL2.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -389,7 +389,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupDimethylStyreneMUL5Test() throws Exception {
     String fileName = "Sgroups_MultipleGroup 01.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -403,7 +403,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupTetramethylnonaneMUL2Test() throws Exception {
     String fileName = "tetramethylnonane_MUL2.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -416,7 +416,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupDecamethylpentadecane_MUL5Test() throws Exception {
     String fileName = "decamethylpentadecane_MUL5.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -429,7 +429,7 @@ public class IntegrationTest {
   @Test
   public void multipleGroupTrimethylnonane_MUL3Test() throws Exception {
     String fileName = "trimethylnonane_MUL3.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -442,7 +442,7 @@ public class IntegrationTest {
   @Test
   public void rgroups_OnlyR_Test() throws IOException {
     String fileName = "simple_rgroups.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/" + fileName);
+    InputStream in = IntegrationTest.class.getResourceAsStream("/integrationTests/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/MarkushTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/MarkushTest.java
@@ -41,7 +41,7 @@ public class MarkushTest {
   @Test
   public void testResidues() throws IOException {
     String fileName = "complex_rgroups.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/" + fileName);
+    InputStream in = MarkushTest.class.getResourceAsStream("/integrationTests/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);
@@ -58,7 +58,7 @@ public class MarkushTest {
   @Test
   public void testMarkush_Ar_X_Y() throws IOException {
     String fileName = "Markush_Ar_X_Y.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/markush/" + fileName);
+    InputStream in = MarkushTest.class.getResourceAsStream("/integrationTests/markush/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);
@@ -73,7 +73,7 @@ public class MarkushTest {
   @Test
   public void testMarkush_R_R1() throws IOException, CDKException {
     String fileName = "Markush_R_R1.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/markush/" + fileName);
+    InputStream in = MarkushTest.class.getResourceAsStream("/integrationTests/markush/" + fileName);
     assertNotNull(in);
 
     CDDocument document = CDXReader.readDocument(in);

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/ReactionIntegrationTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/ReactionIntegrationTest.java
@@ -272,7 +272,7 @@ public class ReactionIntegrationTest {
 
   private BCXReaction convertFirstReactionFromCdxFile(String fileName) throws IOException {
     ReactionXtractor xtractor = new ReactionXtractor(SilentChemObjectBuilder.getInstance());
-    try (InputStream in = this.getClass().getResourceAsStream(fileName)) {
+    try (InputStream in = ReactionIntegrationTest.class.getResourceAsStream(fileName)) {
       Assert.assertNotNull(in);
       CDDocument document;
       if (fileName.endsWith(".cdx")) {
@@ -295,7 +295,7 @@ public class ReactionIntegrationTest {
       throws IOException {
     ReactionXtractor xtractor =
         new ReactionXtractor(SilentChemObjectBuilder.getInstance(), sanitize);
-    try (InputStream in = this.getClass().getResourceAsStream(fileName)) {
+    try (InputStream in = ReactionIntegrationTest.class.getResourceAsStream(fileName)) {
       Assert.assertNotNull(in);
       CDDocument document;
       if (fileName.endsWith(".cdx")) {
@@ -316,7 +316,7 @@ public class ReactionIntegrationTest {
         new String[] {"RInChI", "RAuxInfo", "Long-RInChIKey", "Short-RInChIKey", "Web-RInChIKey"};
     final Map<String, String> rinchiFullInformation = new HashMap<>();
 
-    final URL resource = this.getClass().getResource(filename);
+    final URL resource = ReactionIntegrationTest.class.getResource(filename);
     assertThat(resource)
         .describedAs(String.format("File %s not found in classpath!", filename))
         .isNotNull();

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/SgroupTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/SgroupTest.java
@@ -40,7 +40,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupsTest() throws Exception {
     String fileName = "multipleGroups.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -55,7 +55,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupNonaneMUL2Test() throws Exception {
     String fileName = "nonane_MUL2.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -68,7 +68,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupDimethylOctanceMUL2Test() throws Exception {
     String fileName = "dimethyloctane_MUL2.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -81,7 +81,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupDimethylStyreneMUL5Test() throws Exception {
     String fileName = "Sgroups_MultipleGroup 01.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -95,7 +95,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupTetramethylnonaneMUL2Test() throws Exception {
     String fileName = "tetramethylnonane_MUL2.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -108,7 +108,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupDecamethylpentadecane_MUL5Test() throws Exception {
     String fileName = "decamethylpentadecane_MUL5.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -121,7 +121,7 @@ public class SgroupTest {
   @Test
   public void multipleGroupTrimethylnonane_MUL3Test() throws Exception {
     String fileName = "trimethylnonane_MUL3.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);
@@ -134,7 +134,7 @@ public class SgroupTest {
   @Test
   public void multiple_groups_Test() throws IOException {
     String fileName = "multiple_groups.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/integrationTests/sgroups/" + fileName);
+    InputStream in = SgroupTest.class.getResourceAsStream("/integrationTests/sgroups/" + fileName);
     Assert.assertNotNull(in);
     CDDocument document = CDXReader.readDocument(in);
     Assert.assertNotNull(document);

--- a/src/test/java/org/beilstein/chemxtract/visitor/FragmentVisitorTest.java
+++ b/src/test/java/org/beilstein/chemxtract/visitor/FragmentVisitorTest.java
@@ -45,7 +45,7 @@ public class FragmentVisitorTest {
   public void test() throws IOException {
     String fileName = "nicknames.cdx";
     //    String fileName = "abbreviation.cdx";
-    InputStream in = this.getClass().getResourceAsStream("/cdx/reader/" + fileName);
+    InputStream in = FragmentVisitorTest.class.getResourceAsStream("/cdx/reader/" + fileName);
     assertThat(in).isNotNull();
 
     CDDocument document = CDXReader.readDocument(in);


### PR DESCRIPTION
## Summary

Address all 172 open CodeQL code-scanning alerts on this repository ([security/code-scanning](https://github.com/Beilstein-Institut/BChemXtract/security/code-scanning)). The work is split into six commits, one per rule (or rule cluster).

| Commit | Rule(s) | Alerts |
|---|---|---|
| `chore: replace getClass().getResource ...` | `java/unsafe-get-resource` | 50 (warnings) |
| `chore: close resource streams reliably ...` | `java/input-resource-leak` | 3 (warnings) |
| `chore: silence unused-parameter alerts ...` | `java/unused-parameter` | 29 (notes) |
| `chore: address miscellaneous CodeQL notes` | `java/call-to-object-tostring` + `java/deprecated-call` + `java/local-variable-is-never-read` | 8 (notes) |
| `refactor: defensive-copy list getters ...` | `java/internal-representation-exposure` | 62 (notes) |
| `chore: handle NumberFormatException ...` | `java/uncaught-number-format-exception` | 20 (notes) |

The biggest change is the internal-representation-exposure fix: model classes (`CDPage`, `CDFragment`, `CDGroup`, ...) used to return their internal `List<T>` fields directly from getters, and the reader pipeline mutated them via `thing.getXxx().add(item)`. Getters now return `Collections.unmodifiableList(...)`, setters defensive-copy, and each list field gets a matching `addXxx(T item)` (and a few `addAllXxx`) mutator. All call sites in `CDXReader`, `CDXMLReader`, `CDXMLUtils`, `CDXProperty`, `CDXUtils`, `CDDocumentUtils`, `XMLReaderHandler`, and `SgroupHandler` are updated. The original grep pass missed the multi-line `CDStyledString` chunk appenders — those are covered too.

The `NumberFormatException` fix wraps every flagged parse in the CDXML parser with an explicit catch: most re-throw as `IllegalArgumentException` (or `IOException` where the method already declares it) with the failing value as context; the spectrum-data-point loop and the element-list parse log a warning and skip the malformed entry, matching the parser's existing tolerance.

## Test plan

- [x] `mvn -B -ntp -DskipTests clean compile test-compile` — passes
- [x] `mvn -B -ntp test` — 195 tests, 0 failures, 0 errors, 7 skipped (pre-existing skips)
- [ ] CodeQL re-runs on the PR and reports 0 of the 172 alerts remaining
