### PR TITLE
fix: align InChI generation boundary with SMILES at 500 atoms

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
+++ b/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
@@ -289,7 +289,7 @@ public class SubstanceXtractor {
     substance.setSmiles(smiles);
     substance.setExtendedSmiles(ChemicalUtils.createExtendedSmiles(atomContainer));
     // set InChI, InChIKey and AuxInfo
-    if (atomContainer.getAtomCount() < 500) {
+    if (atomContainer.getAtomCount() <= 500) {
       InChIGenerator gen = ChemicalUtils.getInChI(atomContainer);
       substance.setInchi(gen.getInchi());
       substance.setInchiKey(gen.getInchiKey());


### PR DESCRIPTION
## Summary
- `SubstanceXtractor.createAndFillBCXSubstance` used asymmetric thresholds: the SMILES branch checked `atomCount > 500` (cheap ISOMERIC path) while the InChI block checked `atomCount < 500`. A substance with exactly 500 atoms therefore got ABSOLUTE SMILES but no InChI/InChIKey/AuxInfo — silently inconsistent with the documented "atoms > 500 skip InChI" behavior.
- Change `<` to `<=` on the InChI block (one character) so both sides share the same boundary. At atomCount == 500, the full path now runs end-to-end.

## Test plan
- [x] `mvn spotless:apply` — no-op (no formatting changes)
- [x] `mvn -Dtest=IntegrationTest test` — 24/24 pass
- [ ] CI green on lint + build