### PR TITLE
test: drop unused getter parameter from equals/hashCode flag tests

### DIFF
--- a/src/test/java/org/beilstein/chemxtract/cdx/datatypes/CDOvalTypeTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/datatypes/CDOvalTypeTest.java
@@ -134,8 +134,7 @@ public class CDOvalTypeTest {
 
   @ParameterizedTest(name = "differs on {0}")
   @MethodSource("flags")
-  public void equalsAndHashCodeAreSensitiveToEachFlag(
-      String name, Consumer<CDOvalType> setter) {
+  public void equalsAndHashCodeAreSensitiveToEachFlag(String name, Consumer<CDOvalType> setter) {
     CDOvalType a = new CDOvalType();
     CDOvalType b = new CDOvalType();
     setter.accept(b);

--- a/src/test/java/org/beilstein/chemxtract/cdx/datatypes/CDOvalTypeTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/datatypes/CDOvalTypeTest.java
@@ -135,7 +135,7 @@ public class CDOvalTypeTest {
   @ParameterizedTest(name = "differs on {0}")
   @MethodSource("flags")
   public void equalsAndHashCodeAreSensitiveToEachFlag(
-      String name, Consumer<CDOvalType> setter, Predicate<CDOvalType> getter) {
+      String name, Consumer<CDOvalType> setter) {
     CDOvalType a = new CDOvalType();
     CDOvalType b = new CDOvalType();
     setter.accept(b);

--- a/src/test/java/org/beilstein/chemxtract/cdx/datatypes/CDRectangleTypeTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cdx/datatypes/CDRectangleTypeTest.java
@@ -135,7 +135,7 @@ public class CDRectangleTypeTest {
   @ParameterizedTest(name = "differs on {0}")
   @MethodSource("flags")
   public void equalsAndHashCodeAreSensitiveToEachFlag(
-      String name, Consumer<CDRectangleType> setter, Predicate<CDRectangleType> getter) {
+      String name, Consumer<CDRectangleType> setter) {
     CDRectangleType a = new CDRectangleType();
     CDRectangleType b = new CDRectangleType();
     setter.accept(b);


### PR DESCRIPTION
CodeQL flagged the 'getter' parameter as unused in equalsAndHashCodeAreSensitiveToEachFlag in CDRectangleTypeTest and CDOvalTypeTest. That test only needs the flag name and setter; the shared flags() MethodSource still supplies getter for the sibling test that does use it (JUnit ignores the surplus argument).

<!--
Thank you for contributing to BChemXtract!

PR titles MUST follow Conventional Commits — release-please uses them
to drive versioning and the CHANGELOG. Examples:
  feat: add support for ChemDraw 23 abbreviations
  fix: NPE in BCXReactionInfo when no products
  feat!: drop Java 11 support     (the `!` marks a breaking change)

Allowed types: feat, fix, perf, revert, build, chore, ci, docs, refactor,
                style, test
-->

## Summary

<!-- 1–3 bullets describing the change and the motivation. -->

## Type of change

- [ ] feat — new feature (minor bump)
- [ ] fix — bug fix (patch bump)
- [ ] perf — performance improvement (patch bump)
- [ ] BREAKING CHANGE — incompatible change (`!` in title or footer; major bump)
- [ ] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [ ] PR title follows Conventional Commits
- [ ] `mvn -B verify` passes locally
- [ ] `mvn spotless:apply` was run (or `mvn spotless:check` is clean)
- [ ] New behavior is covered by tests
- [ ] Public API changes are documented (Javadoc + README/HOWTO if applicable)

## Related issues

<!-- Closes #123, refs #456, etc. -->
