### PR TITLE
feat: lay out expanded abbreviation coordinates

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/cheminf/AbbreviationLayout.java
+++ b/src/main/java/org/beilstein/chemxtract/cheminf/AbbreviationLayout.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2025-2030 Beilstein-Institut
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+package org.beilstein.chemxtract.cheminf;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.vecmath.Point2d;
+import org.beilstein.chemxtract.utils.ChemicalUtils;
+import org.beilstein.chemxtract.utils.Definitions;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.layout.StructureDiagramGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generates 2D coordinates for atoms of expanded ChemDraw abbreviations. When an abbreviation is
+ * resolved into an explicit substructure, all of its atoms are stamped with the single coordinate
+ * of the connection point, collapsing them onto one point. This class runs CDK partial layout with
+ * the already-positioned scaffold held fixed, so only the collapsed atoms are placed, preserving
+ * the original ChemDraw layout of the rest of the structure.
+ *
+ * <p>Must be invoked only after stereochemistry has been perceived, because the collapsed
+ * coordinate is what gives scaffold stereocentres a valid wedge direction during perception.
+ */
+public final class AbbreviationLayout {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbbreviationLayout.class);
+  private static final double DEFAULT_BOND_LENGTH = 1.5;
+
+  private AbbreviationLayout() {
+    // static utility
+  }
+
+  /**
+   * Spreads out atoms that share a coordinate (collapsed expanded abbreviations) using partial 2D
+   * layout, keeping validly-positioned scaffold atoms fixed. No-op when the container has no
+   * duplicate coordinates or exceeds {@link Definitions#MAX_ATOM_COUNT}.
+   *
+   * @param container the atom container to lay out; modified in place
+   * @throws CDKException if coordinate generation fails
+   */
+  public static void layoutExpandedAbbreviations(IAtomContainer container) throws CDKException {
+    if (container == null || !ChemicalUtils.hasDuplicateCoordinates(container)) {
+      return;
+    }
+    if (container.getAtomCount() > Definitions.MAX_ATOM_COUNT) {
+      return;
+    }
+
+    Set<IAtom> freeAtoms = findCollapsedAtoms(container);
+    if (freeAtoms.isEmpty()) {
+      return;
+    }
+
+    Set<IAtom> fixedAtoms = new HashSet<>();
+    for (IAtom atom : container.atoms()) {
+      if (!freeAtoms.contains(atom) && atom.getPoint2d() != null) {
+        fixedAtoms.add(atom);
+      }
+    }
+
+    StructureDiagramGenerator sdg = new StructureDiagramGenerator();
+    if (fixedAtoms.isEmpty()) {
+      // Nothing to anchor to: lay the whole structure out fresh.
+      sdg.generateCoordinates(container);
+      return;
+    }
+
+    double targetBondLength = averageFixedBondLength(container, fixedAtoms);
+
+    // Clear collapsed coordinates so the generator treats them as unplaced.
+    for (IAtom atom : freeAtoms) {
+      atom.setPoint2d(null);
+      atom.setPoint3d(null);
+    }
+
+    Set<IBond> fixedBonds = new HashSet<>();
+    for (IBond bond : container.bonds()) {
+      if (fixedAtoms.contains(bond.getBegin()) && fixedAtoms.contains(bond.getEnd())) {
+        fixedBonds.add(bond);
+      }
+    }
+
+    // CDK 2.12's StructureDiagramGenerator.setBondLength(double) always throws
+    // UnsupportedOperationException (bond length is fixed internally at 1.5; rescaling is meant
+    // to happen post-layout via GeometryUtil.scaleMolecule). That whole-molecule helper would also
+    // shift the fixed scaffold atoms, so instead we rescale only the newly-placed atoms afterwards,
+    // anchored on their attachment point(s) into the fixed scaffold.
+    sdg.setMolecule(container, false, fixedAtoms, fixedBonds);
+    sdg.generateCoordinates();
+    rescaleFreeAtoms(container, freeAtoms, fixedAtoms, targetBondLength);
+    LOGGER.debug("Laid out {} collapsed abbreviation atom(s).", freeAtoms.size());
+  }
+
+  /**
+   * Scales each connected group of newly-placed atoms so its bond lengths approximate {@code
+   * targetBondLength}, anchored on the fixed scaffold atom(s) it attaches to. Because this is a
+   * uniform scaling about a fixed centre, every pairwise distance within a group scales by the same
+   * factor, so the anchor atom itself never moves.
+   */
+  private static void rescaleFreeAtoms(
+      IAtomContainer container,
+      Set<IAtom> freeAtoms,
+      Set<IAtom> fixedAtoms,
+      double targetBondLength) {
+    double generatedBondLength = averageBondLengthTouching(container, freeAtoms);
+    if (generatedBondLength <= 0.0) {
+      return;
+    }
+    double factor = targetBondLength / generatedBondLength;
+
+    Set<IAtom> visited = new HashSet<>();
+    for (IAtom start : freeAtoms) {
+      if (!visited.add(start)) {
+        continue;
+      }
+      List<IAtom> component = new ArrayList<>();
+      Set<IAtom> anchors = new HashSet<>();
+      Deque<IAtom> queue = new ArrayDeque<>();
+      queue.add(start);
+      component.add(start);
+      while (!queue.isEmpty()) {
+        IAtom current = queue.poll();
+        for (IBond bond : container.getConnectedBondsList(current)) {
+          IAtom other = bond.getOther(current);
+          if (fixedAtoms.contains(other)) {
+            anchors.add(other);
+          } else if (freeAtoms.contains(other) && visited.add(other)) {
+            component.add(other);
+            queue.add(other);
+          }
+        }
+      }
+      if (anchors.isEmpty()) {
+        continue;
+      }
+      Point2d anchor = centroid(anchors);
+      for (IAtom atom : component) {
+        Point2d p = atom.getPoint2d();
+        if (p == null) {
+          continue;
+        }
+        atom.setPoint2d(
+            new Point2d(
+                anchor.x + (p.x - anchor.x) * factor, anchor.y + (p.y - anchor.y) * factor));
+      }
+    }
+  }
+
+  /** Average length of bonds that touch at least one free (newly-placed) atom. */
+  private static double averageBondLengthTouching(IAtomContainer container, Set<IAtom> freeAtoms) {
+    double sum = 0.0;
+    int count = 0;
+    for (IBond bond : container.bonds()) {
+      IAtom a = bond.getBegin();
+      IAtom b = bond.getEnd();
+      if ((freeAtoms.contains(a) || freeAtoms.contains(b))
+          && a.getPoint2d() != null
+          && b.getPoint2d() != null) {
+        sum += a.getPoint2d().distance(b.getPoint2d());
+        count++;
+      }
+    }
+    return count == 0 ? 0.0 : sum / count;
+  }
+
+  /** Centroid of the 2D coordinates of the given atoms. */
+  private static Point2d centroid(Set<IAtom> atoms) {
+    double sumX = 0.0;
+    double sumY = 0.0;
+    int count = 0;
+    for (IAtom atom : atoms) {
+      Point2d p = atom.getPoint2d();
+      if (p != null) {
+        sumX += p.x;
+        sumY += p.y;
+        count++;
+      }
+    }
+    return count == 0 ? new Point2d(0.0, 0.0) : new Point2d(sumX / count, sumY / count);
+  }
+
+  /**
+   * Returns the atoms that sit on a 2D coordinate shared by more than one atom (the collapsed
+   * expanded-abbreviation atoms).
+   */
+  private static Set<IAtom> findCollapsedAtoms(IAtomContainer container) {
+    Map<String, List<IAtom>> byPoint = new HashMap<>();
+    for (IAtom atom : container.atoms()) {
+      Point2d p = atom.getPoint2d();
+      if (p == null) {
+        continue;
+      }
+      String key = String.format("%.4f,%.4f", p.x, p.y);
+      byPoint.computeIfAbsent(key, k -> new ArrayList<>()).add(atom);
+    }
+    Set<IAtom> collapsed = new HashSet<>();
+    for (List<IAtom> group : byPoint.values()) {
+      if (group.size() > 1) {
+        collapsed.addAll(group);
+      }
+    }
+    return collapsed;
+  }
+
+  /** Average bond length over bonds whose endpoints are both fixed (both carry coordinates). */
+  private static double averageFixedBondLength(IAtomContainer container, Set<IAtom> fixedAtoms) {
+    double sum = 0.0;
+    int count = 0;
+    for (IBond bond : container.bonds()) {
+      IAtom a = bond.getBegin();
+      IAtom b = bond.getEnd();
+      if (fixedAtoms.contains(a)
+          && fixedAtoms.contains(b)
+          && a.getPoint2d() != null
+          && b.getPoint2d() != null) {
+        sum += a.getPoint2d().distance(b.getPoint2d());
+        count++;
+      }
+    }
+    if (count == 0 || sum <= 0.0) {
+      return DEFAULT_BOND_LENGTH;
+    }
+    return sum / count;
+  }
+}

--- a/src/main/java/org/beilstein/chemxtract/cheminf/AbbreviationLayout.java
+++ b/src/main/java/org/beilstein/chemxtract/cheminf/AbbreviationLayout.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.vecmath.Point2d;
-import org.beilstein.chemxtract.utils.ChemicalUtils;
 import org.beilstein.chemxtract.utils.Definitions;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtom;
@@ -49,6 +48,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Must be invoked only after stereochemistry has been perceived, because the collapsed
  * coordinate is what gives scaffold stereocentres a valid wedge direction during perception.
+ *
+ * <p>Only the atoms explicitly passed in are laid out; the caller is responsible for supplying
+ * exactly the atoms produced by abbreviation resubstitution so unrelated collapsed-coordinate
+ * structures (e.g. ChemDraw "Multiple Group" sgroups) are never touched.
  */
 public final class AbbreviationLayout {
 
@@ -60,23 +63,25 @@ public final class AbbreviationLayout {
   }
 
   /**
-   * Spreads out atoms that share a coordinate (collapsed expanded abbreviations) using partial 2D
-   * layout, keeping validly-positioned scaffold atoms fixed. No-op when the container has no
-   * duplicate coordinates or exceeds {@link Definitions#MAX_ATOM_COUNT}.
+   * Spreads out the given expanded-abbreviation atoms (all collapsed onto their connection point by
+   * {@code FragmentConverter.resubstituteAbbreviation}) using CDK partial 2D layout, keeping every
+   * other validly-positioned scaffold atom fixed so the original ChemDraw layout is preserved.
+   * No-op when {@code freeAtoms} is empty or the container exceeds {@link
+   * Definitions#MAX_ATOM_COUNT}.
+   *
+   * <p>Must be invoked only after stereochemistry has been perceived: the collapsed coordinate is
+   * what gives scaffold stereocentres a valid wedge direction during perception.
    *
    * @param container the atom container to lay out; modified in place
+   * @param freeAtoms the atoms produced by abbreviation resubstitution (the atoms to place)
    * @throws CDKException if coordinate generation fails
    */
-  public static void layoutExpandedAbbreviations(IAtomContainer container) throws CDKException {
-    if (container == null || !ChemicalUtils.hasDuplicateCoordinates(container)) {
+  public static void layoutExpandedAbbreviations(IAtomContainer container, Set<IAtom> freeAtoms)
+      throws CDKException {
+    if (container == null || freeAtoms == null || freeAtoms.isEmpty()) {
       return;
     }
     if (container.getAtomCount() > Definitions.MAX_ATOM_COUNT) {
-      return;
-    }
-
-    Set<IAtom> freeAtoms = findCollapsedAtoms(container);
-    if (freeAtoms.isEmpty()) {
       return;
     }
 
@@ -96,6 +101,14 @@ public final class AbbreviationLayout {
 
     double targetBondLength = averageFixedBondLength(container, fixedAtoms);
 
+    // Snapshot the collapsed coordinates so they can be restored verbatim if layout fails
+    // partway through: a failed attempt must leave the container exactly as it was, never in an
+    // intermediate (nulled-out) state that would silently change downstream chemistry.
+    Map<IAtom, Point2d> originalPoints = new HashMap<>();
+    for (IAtom atom : freeAtoms) {
+      originalPoints.put(atom, atom.getPoint2d());
+    }
+
     // Clear collapsed coordinates so the generator treats them as unplaced.
     for (IAtom atom : freeAtoms) {
       atom.setPoint2d(null);
@@ -109,15 +122,22 @@ public final class AbbreviationLayout {
       }
     }
 
-    // CDK 2.12's StructureDiagramGenerator.setBondLength(double) always throws
-    // UnsupportedOperationException (bond length is fixed internally at 1.5; rescaling is meant
-    // to happen post-layout via GeometryUtil.scaleMolecule). That whole-molecule helper would also
-    // shift the fixed scaffold atoms, so instead we rescale only the newly-placed atoms afterwards,
-    // anchored on their attachment point(s) into the fixed scaffold.
-    sdg.setMolecule(container, false, fixedAtoms, fixedBonds);
-    sdg.generateCoordinates();
-    rescaleFreeAtoms(container, freeAtoms, fixedAtoms, targetBondLength);
-    LOGGER.debug("Laid out {} collapsed abbreviation atom(s).", freeAtoms.size());
+    try {
+      // CDK 2.12's StructureDiagramGenerator.setBondLength(double) always throws
+      // UnsupportedOperationException (bond length is fixed internally at 1.5; rescaling is meant
+      // to happen post-layout via GeometryUtil.scaleMolecule). That whole-molecule helper would
+      // also shift the fixed scaffold atoms, so instead we rescale only the newly-placed atoms
+      // afterwards, anchored on their attachment point(s) into the fixed scaffold.
+      sdg.setMolecule(container, false, fixedAtoms, fixedBonds);
+      sdg.generateCoordinates();
+      rescaleFreeAtoms(container, freeAtoms, fixedAtoms, targetBondLength);
+      LOGGER.debug("Laid out {} expanded abbreviation atom(s).", freeAtoms.size());
+    } catch (CDKException | RuntimeException e) {
+      for (Map.Entry<IAtom, Point2d> entry : originalPoints.entrySet()) {
+        entry.getKey().setPoint2d(entry.getValue());
+      }
+      throw e;
+    }
   }
 
   /**
@@ -206,29 +226,6 @@ public final class AbbreviationLayout {
       }
     }
     return count == 0 ? new Point2d(0.0, 0.0) : new Point2d(sumX / count, sumY / count);
-  }
-
-  /**
-   * Returns the atoms that sit on a 2D coordinate shared by more than one atom (the collapsed
-   * expanded-abbreviation atoms).
-   */
-  private static Set<IAtom> findCollapsedAtoms(IAtomContainer container) {
-    Map<String, List<IAtom>> byPoint = new HashMap<>();
-    for (IAtom atom : container.atoms()) {
-      Point2d p = atom.getPoint2d();
-      if (p == null) {
-        continue;
-      }
-      String key = String.format("%.4f,%.4f", p.x, p.y);
-      byPoint.computeIfAbsent(key, k -> new ArrayList<>()).add(atom);
-    }
-    Set<IAtom> collapsed = new HashSet<>();
-    for (List<IAtom> group : byPoint.values()) {
-      if (group.size() > 1) {
-        collapsed.addAll(group);
-      }
-    }
-    return collapsed;
   }
 
   /** Average bond length over bonds whose endpoints are both fixed (both carry coordinates). */

--- a/src/main/java/org/beilstein/chemxtract/converter/FragmentConverter.java
+++ b/src/main/java/org/beilstein/chemxtract/converter/FragmentConverter.java
@@ -23,6 +23,7 @@ package org.beilstein.chemxtract.converter;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,6 +35,7 @@ import org.beilstein.chemxtract.cdx.CDFragment;
 import org.beilstein.chemxtract.cdx.datatypes.CDBondOrder;
 import org.beilstein.chemxtract.cdx.datatypes.CDNodeType;
 import org.beilstein.chemxtract.cdx.datatypes.CDRadical;
+import org.beilstein.chemxtract.cheminf.AbbreviationLayout;
 import org.beilstein.chemxtract.lookups.SmilesAbbreviations;
 import org.beilstein.chemxtract.utils.StereoHandler;
 import org.beilstein.chemxtract.visitor.AtomVisitor;
@@ -164,8 +166,10 @@ public class FragmentConverter {
       }
     }
     // create IAtomContainer from the structural (non-coordination) skeleton
+    Set<IAtom> abbreviationAtoms = new HashSet<>();
     IAtomContainer atomContainer =
-        createAtomContainer(atoms.toArray(IAtom[]::new), structuralBonds.toArray(IBond[]::new));
+        createAtomContainer(
+            atoms.toArray(IAtom[]::new), structuralBonds.toArray(IBond[]::new), abbreviationAtoms);
     // check for radicals
     setRadicals(atomContainer, atomConverter.getAtomMap());
     // add implicit hydrogens (ligands are still free of their coordinating metal here)
@@ -176,6 +180,12 @@ public class FragmentConverter {
     addCoordinationBonds(atomContainer, coordinationBonds);
     // check for tetrahedral stereo
     StereoHandler.setStereo(atomContainer, bondConverter.getBondMap(), atomConverter.getAtomMap());
+    // generate coordinates for expanded-abbreviation atoms (after stereo perception)
+    try {
+      AbbreviationLayout.layoutExpandedAbbreviations(atomContainer, abbreviationAtoms);
+    } catch (CDKException | RuntimeException e) {
+      LOGGER.warn("Abbreviation layout failed; keeping collapsed coordinates.", e);
+    }
     return atomContainer;
   }
 
@@ -248,9 +258,11 @@ public class FragmentConverter {
    *
    * @param atoms array of {@link IAtom}
    * @param bonds array of {@link IBond}
+   * @param abbreviationAtomsOut collector for atoms produced by abbreviation resubstitution
    * @return the assembled {@link IAtomContainer}
    */
-  private IAtomContainer createAtomContainer(IAtom[] atoms, IBond[] bonds) {
+  private IAtomContainer createAtomContainer(
+      IAtom[] atoms, IBond[] bonds, Set<IAtom> abbreviationAtomsOut) {
     IAtomContainer atomContainer = builder.newAtomContainer();
     atomContainer.setAtoms(atoms);
 
@@ -258,16 +270,14 @@ public class FragmentConverter {
     for (IBond bond : bonds) {
       IAtom a0 = bond.getAtom(0);
       IAtom a1 = bond.getAtom(1); // always exists for a valid bond
-
       int idx0 = atomContainer.indexOf(a0);
       int idx1 = atomContainer.indexOf(a1);
-
       if (idx0 >= 0 && idx1 >= 0 && !atomContainer.contains(bond)) {
         atomContainer.addBond(bond);
       }
     }
 
-    resubstituteAbbreviation(atomContainer);
+    abbreviationAtomsOut.addAll(resubstituteAbbreviation(atomContainer));
     return atomContainer;
   }
 
@@ -278,10 +288,12 @@ public class FragmentConverter {
    * <p>
    *
    * @param atomContainer the container in which abbreviations are replaced
+   * @return the set of atoms added to {@code atomContainer} by this resubstitution
    */
-  private void resubstituteAbbreviation(IAtomContainer atomContainer) {
+  private Set<IAtom> resubstituteAbbreviation(IAtomContainer atomContainer) {
     List<IBond> bondsToRemove = new ArrayList<>();
     List<IAtom> atomsToRemove = new ArrayList<>();
+    Set<IAtom> addedAtoms = new HashSet<>();
 
     for (IAtom atom : atomContainer.atoms()) {
       if (!(atom instanceof IPseudoAtom pseudoAtom)) {
@@ -314,14 +326,16 @@ public class FragmentConverter {
       }
 
       if (expandedStructure.getAtomCount() == 1) {
-        replaceSingleAtom(atomContainer, pseudoAtom, expandedStructure.getAtom(0), atomsToRemove);
+        replaceSingleAtom(
+            atomContainer, pseudoAtom, expandedStructure.getAtom(0), atomsToRemove, addedAtoms);
       } else {
         replaceMultiAtom(
-            atomContainer, pseudoAtom, expandedStructure, bondsToRemove, atomsToRemove);
+            atomContainer, pseudoAtom, expandedStructure, bondsToRemove, atomsToRemove, addedAtoms);
       }
     }
     bondsToRemove.forEach(atomContainer::removeBond);
     atomsToRemove.forEach(atomContainer::removeAtom);
+    return addedAtoms;
   }
 
   /**
@@ -332,10 +346,16 @@ public class FragmentConverter {
    * @param pseudoAtom abbreviation/R atom (IAtom) to be replaced
    * @param newAtom IAtom to replace the rAtom
    * @param atomsToRemove list of atoms that will be removed from the IAtomContainer
+   * @param addedAtoms collector for atoms added to the IAtomContainer
    */
   private void replaceSingleAtom(
-      IAtomContainer atomContainer, IAtom pseudoAtom, IAtom newAtom, List<IAtom> atomsToRemove) {
+      IAtomContainer atomContainer,
+      IAtom pseudoAtom,
+      IAtom newAtom,
+      List<IAtom> atomsToRemove,
+      Set<IAtom> addedAtoms) {
     atomContainer.addAtom(newAtom);
+    addedAtoms.add(newAtom);
 
     List<IBond> connectedBonds = new ArrayList<>();
     pseudoAtom.bonds().forEach(connectedBonds::add);
@@ -356,13 +376,15 @@ public class FragmentConverter {
    * @param expandedStructure IAtomContainer of the structure parsed from the abbreviation SMILES
    * @param bondsToRemove list of bonds that will be removed from the IAtomContainer
    * @param atomsToRemove list of atoms that will be removed from the IAtomContainer
+   * @param addedAtoms collector for atoms added to the IAtomContainer
    */
   private void replaceMultiAtom(
       IAtomContainer atomContainer,
       IAtom pseudoAtom,
       IAtomContainer expandedStructure,
       List<IBond> bondsToRemove,
-      List<IAtom> atomsToRemove) {
+      List<IAtom> atomsToRemove,
+      Set<IAtom> addedAtoms) {
     List<IAtom> connectionPoints = new ArrayList<>();
     for (IAtom atom : expandedStructure.atoms()) {
       if (atom instanceof IPseudoAtom) {
@@ -392,6 +414,11 @@ public class FragmentConverter {
 
     atomContainer.add(expandedStructure);
     atomContainer.addBond(newBond);
+    for (IAtom expandedAtom : expandedStructure.atoms()) {
+      if (expandedAtom != connectionPoint) {
+        addedAtoms.add(expandedAtom);
+      }
+    }
 
     bondsToRemove.add(bondOrigin);
     bondsToRemove.add(bondInsideAbbr);

--- a/src/main/java/org/beilstein/chemxtract/converter/FragmentConverter.java
+++ b/src/main/java/org/beilstein/chemxtract/converter/FragmentConverter.java
@@ -326,8 +326,7 @@ public class FragmentConverter {
       }
 
       if (expandedStructure.getAtomCount() == 1) {
-        replaceSingleAtom(
-            atomContainer, pseudoAtom, expandedStructure.getAtom(0), atomsToRemove, addedAtoms);
+        replaceSingleAtom(atomContainer, pseudoAtom, expandedStructure.getAtom(0), atomsToRemove);
       } else {
         replaceMultiAtom(
             atomContainer, pseudoAtom, expandedStructure, bondsToRemove, atomsToRemove, addedAtoms);
@@ -346,16 +345,10 @@ public class FragmentConverter {
    * @param pseudoAtom abbreviation/R atom (IAtom) to be replaced
    * @param newAtom IAtom to replace the rAtom
    * @param atomsToRemove list of atoms that will be removed from the IAtomContainer
-   * @param addedAtoms collector for atoms added to the IAtomContainer
    */
   private void replaceSingleAtom(
-      IAtomContainer atomContainer,
-      IAtom pseudoAtom,
-      IAtom newAtom,
-      List<IAtom> atomsToRemove,
-      Set<IAtom> addedAtoms) {
+      IAtomContainer atomContainer, IAtom pseudoAtom, IAtom newAtom, List<IAtom> atomsToRemove) {
     atomContainer.addAtom(newAtom);
-    addedAtoms.add(newAtom);
 
     List<IBond> connectedBonds = new ArrayList<>();
     pseudoAtom.bonds().forEach(connectedBonds::add);

--- a/src/main/java/org/beilstein/chemxtract/utils/Definitions.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/Definitions.java
@@ -42,6 +42,13 @@ public class Definitions {
   public static final String AGENT_ABBREVIATION_PATH =
       "/org/beilstein/chemxtract/lookups/agents_abbreviations.smi";
   public static final int AGENTS_SIZE = 400;
+
+  /**
+   * Upper bound on atom count for expensive per-structure operations (InChI generation and 2D
+   * coordinate layout). Larger structures fall back to cheaper handling.
+   */
+  public static final int MAX_ATOM_COUNT = 500;
+
   // Regular expression for splitting:
   // \s includes all whitespace (spaces, tabs, line feeds, etc.)
   // \n ensures we explicitly catch line feeds (optional since \s includes it)

--- a/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
+++ b/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
@@ -41,6 +41,7 @@ import org.beilstein.chemxtract.model.BCXSubstanceInfo;
 import org.beilstein.chemxtract.model.BCXSubstanceOccurrence;
 import org.beilstein.chemxtract.utils.AttachmentHandler;
 import org.beilstein.chemxtract.utils.ChemicalUtils;
+import org.beilstein.chemxtract.utils.Definitions;
 import org.beilstein.chemxtract.utils.MarkushHandler;
 import org.beilstein.chemxtract.utils.SgroupHandler;
 import org.beilstein.chemxtract.visitor.FragmentVisitor;
@@ -310,7 +311,7 @@ public class SubstanceXtractor {
     }
     // set SMILES
     String smiles;
-    if (atomContainer.getAtomCount() > 500) {
+    if (atomContainer.getAtomCount() > Definitions.MAX_ATOM_COUNT) {
       smiles = ChemicalUtils.createSmiles(atomContainer, SmiFlavor.Isomeric);
     } else {
       smiles = ChemicalUtils.createAbsoluteSmiles(atomContainer);
@@ -325,7 +326,7 @@ public class SubstanceXtractor {
     // set InChI, InChIKey and AuxInfo. A structure containing unresolved pseudo-atoms (e.g. an
     // R-group whose attachment position varies) cannot be represented in InChI, but is still a
     // valid extraction carrying SMILES and a molecular formula; other InChI failures remain fatal.
-    if (atomContainer.getAtomCount() <= 500) {
+    if (atomContainer.getAtomCount() <= Definitions.MAX_ATOM_COUNT) {
       try {
         InChIGenerator gen = ChemicalUtils.getInChI(atomContainer);
         substance.setInchi(gen.getInchi());

--- a/src/test/java/org/beilstein/chemxtract/cheminf/AbbreviationLayoutTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cheminf/AbbreviationLayoutTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025-2030 Beilstein-Institut
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+package org.beilstein.chemxtract.cheminf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.vecmath.Point2d;
+import org.beilstein.chemxtract.utils.ChemicalUtils;
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IBond;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+
+class AbbreviationLayoutTest {
+
+  private static final IChemObjectBuilder BUILDER = SilentChemObjectBuilder.getInstance();
+
+  private static IAtom carbon(double x, double y) {
+    IAtom atom = BUILDER.newAtom();
+    atom.setSymbol("C");
+    atom.setAtomicNumber(6);
+    atom.setPoint2d(new Point2d(x, y));
+    return atom;
+  }
+
+  /** Scaffold c1-c2, with a 3-atom substituent all collapsed onto the connection point (2,0). */
+  private static IAtomContainer collapsedMolecule() {
+    IAtomContainer mol = BUILDER.newAtomContainer();
+    IAtom c1 = carbon(0, 0);
+    IAtom c2 = carbon(1, 0);
+    IAtom c3 = carbon(2, 0);
+    IAtom c4 = carbon(2, 0);
+    IAtom c5 = carbon(2, 0);
+    mol.addAtom(c1);
+    mol.addAtom(c2);
+    mol.addAtom(c3);
+    mol.addAtom(c4);
+    mol.addAtom(c5);
+    mol.addBond(0, 1, IBond.Order.SINGLE);
+    mol.addBond(1, 2, IBond.Order.SINGLE);
+    mol.addBond(2, 3, IBond.Order.SINGLE);
+    mol.addBond(3, 4, IBond.Order.SINGLE);
+    return mol;
+  }
+
+  @Test
+  void collapsedAtomsGetDistinctCoordinates() throws Exception {
+    IAtomContainer mol = collapsedMolecule();
+    Point2d c1Before = new Point2d(mol.getAtom(0).getPoint2d());
+    Point2d c2Before = new Point2d(mol.getAtom(1).getPoint2d());
+
+    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+
+    assertFalse(ChemicalUtils.hasDuplicateCoordinates(mol), "collapsed atoms should be spread out");
+    for (IAtom atom : mol.atoms()) {
+      assertNotNull(atom.getPoint2d(), "every atom must have a 2D coordinate");
+    }
+    assertTrue(
+        c1Before.equals(mol.getAtom(0).getPoint2d()), "fixed scaffold atom c1 must not move");
+    assertTrue(
+        c2Before.equals(mol.getAtom(1).getPoint2d()), "fixed scaffold atom c2 must not move");
+  }
+
+  @Test
+  void moleculeWithoutDuplicatesIsUntouched() throws Exception {
+    IAtomContainer mol = BUILDER.newAtomContainer();
+    mol.addAtom(carbon(0, 0));
+    mol.addAtom(carbon(1, 0));
+    mol.addBond(0, 1, IBond.Order.SINGLE);
+    Point2d a0 = new Point2d(mol.getAtom(0).getPoint2d());
+    Point2d a1 = new Point2d(mol.getAtom(1).getPoint2d());
+
+    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+
+    assertTrue(a0.equals(mol.getAtom(0).getPoint2d()), "coordinates must be unchanged");
+    assertTrue(a1.equals(mol.getAtom(1).getPoint2d()), "coordinates must be unchanged");
+  }
+
+  @Test
+  void allAtomsCollapsedFallsBackToFullLayout() throws Exception {
+    IAtomContainer mol = BUILDER.newAtomContainer();
+    mol.addAtom(carbon(0, 0));
+    mol.addAtom(carbon(0, 0));
+    mol.addAtom(carbon(0, 0));
+    mol.addBond(0, 1, IBond.Order.SINGLE);
+    mol.addBond(1, 2, IBond.Order.SINGLE);
+
+    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+
+    assertFalse(ChemicalUtils.hasDuplicateCoordinates(mol), "full layout should spread atoms");
+    for (IAtom atom : mol.atoms()) {
+      assertNotNull(atom.getPoint2d(), "every atom must have a 2D coordinate");
+    }
+  }
+
+  @Test
+  void oversizedMoleculeIsSkipped() throws Exception {
+    IAtomContainer mol = BUILDER.newAtomContainer();
+    for (int i = 0; i < 502; i++) {
+      mol.addAtom(carbon(0, 0)); // all identical -> duplicates present
+    }
+
+    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+
+    assertTrue(
+        ChemicalUtils.hasDuplicateCoordinates(mol),
+        "layout must be skipped above MAX_ATOM_COUNT, leaving coordinates collapsed");
+  }
+
+  @Test
+  void newBondsRoughlyMatchScaffoldBondLength() throws Exception {
+    // Scaffold bond c1-c2 spans distance 1.0; laid-out bonds should be near that.
+    IAtomContainer mol = collapsedMolecule();
+
+    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+
+    double sum = 0.0;
+    int count = 0;
+    for (IBond bond : mol.bonds()) {
+      sum += bond.getBegin().getPoint2d().distance(bond.getEnd().getPoint2d());
+      count++;
+    }
+    double average = sum / count;
+    assertEquals(1.0, average, 0.3, "laid-out bonds should roughly match the scaffold bond length");
+  }
+}

--- a/src/test/java/org/beilstein/chemxtract/cheminf/AbbreviationLayoutTest.java
+++ b/src/test/java/org/beilstein/chemxtract/cheminf/AbbreviationLayoutTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
 import javax.vecmath.Point2d;
 import org.beilstein.chemxtract.utils.ChemicalUtils;
 import org.junit.jupiter.api.Test;
@@ -70,12 +71,13 @@ class AbbreviationLayoutTest {
   @Test
   void collapsedAtomsGetDistinctCoordinates() throws Exception {
     IAtomContainer mol = collapsedMolecule();
+    Set<IAtom> free = Set.of(mol.getAtom(2), mol.getAtom(3), mol.getAtom(4));
     Point2d c1Before = new Point2d(mol.getAtom(0).getPoint2d());
     Point2d c2Before = new Point2d(mol.getAtom(1).getPoint2d());
 
-    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+    AbbreviationLayout.layoutExpandedAbbreviations(mol, free);
 
-    assertFalse(ChemicalUtils.hasDuplicateCoordinates(mol), "collapsed atoms should be spread out");
+    assertFalse(ChemicalUtils.hasDuplicateCoordinates(mol), "expanded atoms should be spread out");
     for (IAtom atom : mol.atoms()) {
       assertNotNull(atom.getPoint2d(), "every atom must have a 2D coordinate");
     }
@@ -86,30 +88,31 @@ class AbbreviationLayoutTest {
   }
 
   @Test
-  void moleculeWithoutDuplicatesIsUntouched() throws Exception {
+  void emptyFreeSetIsNoOp() throws Exception {
     IAtomContainer mol = BUILDER.newAtomContainer();
     mol.addAtom(carbon(0, 0));
-    mol.addAtom(carbon(1, 0));
+    mol.addAtom(carbon(0, 0)); // duplicate coords present, but nothing is declared free
     mol.addBond(0, 1, IBond.Order.SINGLE);
     Point2d a0 = new Point2d(mol.getAtom(0).getPoint2d());
     Point2d a1 = new Point2d(mol.getAtom(1).getPoint2d());
 
-    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+    AbbreviationLayout.layoutExpandedAbbreviations(mol, Set.of());
 
     assertTrue(a0.equals(mol.getAtom(0).getPoint2d()), "coordinates must be unchanged");
     assertTrue(a1.equals(mol.getAtom(1).getPoint2d()), "coordinates must be unchanged");
   }
 
   @Test
-  void allAtomsCollapsedFallsBackToFullLayout() throws Exception {
+  void allAtomsFreeFallsBackToFullLayout() throws Exception {
     IAtomContainer mol = BUILDER.newAtomContainer();
     mol.addAtom(carbon(0, 0));
     mol.addAtom(carbon(0, 0));
     mol.addAtom(carbon(0, 0));
     mol.addBond(0, 1, IBond.Order.SINGLE);
     mol.addBond(1, 2, IBond.Order.SINGLE);
+    Set<IAtom> free = Set.of(mol.getAtom(0), mol.getAtom(1), mol.getAtom(2));
 
-    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+    AbbreviationLayout.layoutExpandedAbbreviations(mol, free);
 
     assertFalse(ChemicalUtils.hasDuplicateCoordinates(mol), "full layout should spread atoms");
     for (IAtom atom : mol.atoms()) {
@@ -123,8 +126,9 @@ class AbbreviationLayoutTest {
     for (int i = 0; i < 502; i++) {
       mol.addAtom(carbon(0, 0)); // all identical -> duplicates present
     }
+    Set<IAtom> free = Set.of(mol.getAtom(500), mol.getAtom(501));
 
-    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+    AbbreviationLayout.layoutExpandedAbbreviations(mol, free);
 
     assertTrue(
         ChemicalUtils.hasDuplicateCoordinates(mol),
@@ -135,8 +139,9 @@ class AbbreviationLayoutTest {
   void newBondsRoughlyMatchScaffoldBondLength() throws Exception {
     // Scaffold bond c1-c2 spans distance 1.0; laid-out bonds should be near that.
     IAtomContainer mol = collapsedMolecule();
+    Set<IAtom> free = Set.of(mol.getAtom(2), mol.getAtom(3), mol.getAtom(4));
 
-    AbbreviationLayout.layoutExpandedAbbreviations(mol);
+    AbbreviationLayout.layoutExpandedAbbreviations(mol, free);
 
     double sum = 0.0;
     int count = 0;

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/AbbreviationLayoutIntegrationTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/AbbreviationLayoutIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025-2030 Beilstein-Institut
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+package org.beilstein.chemxtract.integrationTests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.List;
+import org.beilstein.chemxtract.cdx.CDDocument;
+import org.beilstein.chemxtract.cdx.reader.CDXReader;
+import org.beilstein.chemxtract.model.BCXSubstance;
+import org.beilstein.chemxtract.model.BCXSubstanceInfo;
+import org.beilstein.chemxtract.utils.ChemicalUtils;
+import org.beilstein.chemxtract.xtractor.SubstanceXtractor;
+import org.junit.jupiter.api.Test;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+
+class AbbreviationLayoutIntegrationTest {
+
+  // Baseline captured from the current extraction (see plan Task 3, Step 2). Layout must not change
+  // it.
+  private static final String BASELINE_INCHIKEY = "AFPHTEQTJZKQAQ-UHFFFAOYSA-N";
+
+  @Test
+  void expandedAbbreviationCoordinatesAreLaidOutWithoutChangingChemistry() throws Exception {
+    InputStream in =
+        AbbreviationLayoutIntegrationTest.class.getResourceAsStream(
+            "/integrationTests/Sgroups_Abbreviations.cdx");
+    assertNotNull(in, "fixture must be on the classpath");
+    CDDocument document = CDXReader.readDocument(in);
+    assertNotNull(document, "document must parse");
+
+    SubstanceXtractor xtractor = new SubstanceXtractor(SilentChemObjectBuilder.getInstance());
+    List<BCXSubstance> substances = xtractor.xtract(document, new BCXSubstanceInfo());
+    assertFalse(substances.isEmpty(), "at least one substance must be extracted");
+
+    BCXSubstance first = substances.get(0);
+
+    // Chemistry is unchanged by coordinate layout.
+    assertEquals(BASELINE_INCHIKEY, first.getInchiKey(), "InChIKey must be unchanged");
+
+    // Coordinates are no longer collapsed.
+    assertFalse(
+        ChemicalUtils.hasDuplicateCoordinates(first.getAtomContainer()),
+        "expanded abbreviation atoms must have distinct coordinates");
+
+    // Extended SMILES now carries a coordinate block (CXSMILES uses the "|...|" suffix).
+    assertTrue(
+        first.getExtendedSmiles().contains("|"),
+        "extended SMILES should include a coordinate block");
+  }
+}


### PR DESCRIPTION
## Summary

Expanded ChemDraw abbreviations (e.g. `Ph`, `Bn`) are resolved by `FragmentConverter.resubstituteAbbreviation()`, which stamps **every** atom of the expanded substructure onto the connection point's single coordinate — collapsing the whole substituent onto one point. This produced degenerate geometry (bad depictions, and `createExtendedSmiles()` dropping the CXSMILES coordinate block).

This PR lays those collapsed atoms out with CDK partial 2D layout, keeping the already-positioned scaffold fixed, so the substituent gets sensible coordinates while the author's original ChemDraw layout is preserved.

## Changes

- **`Definitions.MAX_ATOM_COUNT`** — extracted the two hardcoded `500` literals in `SubstanceXtractor` into a shared constant, reused as the layout size guard (pure refactor, no threshold change).
- **`cheminf/AbbreviationLayout`** — new stateless helper doing partial layout (`StructureDiagramGenerator.setMolecule(mol, false, fixedAtoms, fixedBonds)` + `generateCoordinates()`), then rescaling the newly-placed atoms to the scaffold's bond length about their fixed anchor.
- **`FragmentConverter.convert()`** — invokes the layout **after** `StereoHandler.setStereo()`, passing an **explicit set of the atoms produced by abbreviation resubstitution**. Single-atom expansions (which land on a unique coordinate) are excluded.

## Why the explicit atom set (not duplicate-coordinate detection)

An earlier iteration triggered layout on any molecule with duplicate coordinates. That misfired on unrelated **Multiple-Group sgroup** structures, changing their perceived stereochemistry and merging two stereoisomers in `multiple_groups.cdx` (InChIKey regression). Scoping the layout to exactly the abbreviation-resubstituted atoms leaves every other molecule untouched — chemistry (InChI/InChIKey/SMILES) is byte-stable across the whole test corpus.

## Safety / correctness

- Layout runs only after stereo is stored as topological `IStereoElement`s, so coordinates are cosmetic to InChI generation.
- A failed layout restores the original coordinates and is caught (`CDKException | RuntimeException` — CDK's partial layout throws unchecked), degrading to the prior collapsed-coordinate behavior. Extraction never breaks.
- Layering preserved: `converter → cheminf → utils → CDK`.

## Notes

- CDK 2.12's `StructureDiagramGenerator.setBondLength()` throws `UnsupportedOperationException`; bond-length matching is therefore done post-layout via a uniform rescale about the fixed anchor.

## Testing

- New unit tests for `AbbreviationLayout` (collapsed-atoms-spread, fixed-atoms-immobile, empty-set no-op, full-layout fallback, size guard, bond-length match).
- Full suite green: **335 run, 0 failures, 0 errors, 15 skipped** (pre-existing `@Disabled`).

## Known follow-up

No repo fixture currently exercises the pseudo-atom abbreviation-collapse path end-to-end (existing abbreviation fixtures use ChemDraw nested-fragment abbreviations, which carry real coordinates). The layout algorithm is covered by unit tests; adding a real collapsing-abbreviation `.cdx` fixture is tracked as a follow-up.
