### PR TITLE
fix: preserve tetrahedral stereo in MDL V3000 output

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
+++ b/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
@@ -54,6 +54,7 @@ import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.interfaces.IMolecularFormula;
 import org.openscience.cdk.interfaces.IPseudoAtom;
 import org.openscience.cdk.io.MDLV3000Writer;
+import org.openscience.cdk.layout.StructureDiagramGenerator;
 import org.openscience.cdk.smiles.SmiFlavor;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 import org.slf4j.Logger;
@@ -304,7 +305,7 @@ public class SubstanceXtractor {
     // add MDLV3000 mol file as string
     final StringWriter sw = new StringWriter();
     try (MDLV3000Writer mdlw = new MDLV3000Writer(sw)) {
-      mdlw.write(atomContainer);
+      mdlw.write(withWedgeBonds(atomContainer));
       substance.setMdlv3000(sw.toString());
     } catch (IOException e) {
       LOGGER.error("Could not generate MDL V3000 mol file;");
@@ -346,6 +347,38 @@ public class SubstanceXtractor {
         MolecularFormulaManipulator.getMolecularFormula(atomContainer);
     substance.setMolecularFormula(MolecularFormulaManipulator.getString(molecularFormula));
     return substance;
+  }
+
+  /**
+   * Returns a copy of {@code atomContainer} with up/down wedge bonds assigned from its stereo
+   * elements, for writing the MDL V3000 mol file.
+   *
+   * <p>CDK's {@code MDLV3000Reader} deliberately ignores the atom parity ({@code CFG}) field for
+   * structures that carry 2D coordinates and instead re-perceives tetrahedral stereochemistry from
+   * wedge/hash bonds. The extractor's containers hold {@link
+   * org.openscience.cdk.interfaces.ITetrahedralChirality} elements but no wedge bonds, so {@code
+   * MDLV3000Writer} emits stereo only as atom {@code CFG} — which the reader discards, losing the
+   * stereo on round-trip. {@link StructureDiagramGenerator#generateWedges} assigns the wedge bonds
+   * from the stereo elements without altering the existing layout, making the mol file round-trip
+   * (and interoperate with other toolkits) correctly.
+   *
+   * <p>Wedges are assigned on a clone so the shared container used for SMILES/InChI generation and
+   * exposed via {@link BCXSubstance#getAtomContainer()} is not mutated. If cloning or wedge
+   * assignment fails the original container is returned, preserving the previous behaviour.
+   *
+   * @param atomContainer the container to derive the mol-file structure from
+   * @return a wedge-annotated copy, or the original container if wedge assignment is not possible
+   */
+  private static IAtomContainer withWedgeBonds(IAtomContainer atomContainer) {
+    try {
+      IAtomContainer copy = atomContainer.clone();
+      new StructureDiagramGenerator().generateWedges(copy);
+      return copy;
+    } catch (CloneNotSupportedException | RuntimeException e) {
+      LOGGER.warn(
+          "Could not assign wedge bonds for MDL V3000 mol file; writing without wedges.", e);
+      return atomContainer;
+    }
   }
 
   /**

--- a/src/test/java/org/beilstein/chemxtract/integrationTests/IntegrationTest.java
+++ b/src/test/java/org/beilstein/chemxtract/integrationTests/IntegrationTest.java
@@ -28,13 +28,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.util.*;
 import org.beilstein.chemxtract.cdx.CDDocument;
 import org.beilstein.chemxtract.cdx.reader.CDXReader;
 import org.beilstein.chemxtract.model.BCXSubstance;
 import org.beilstein.chemxtract.model.BCXSubstanceInfo;
+import org.beilstein.chemxtract.utils.ChemicalUtils;
 import org.beilstein.chemxtract.xtractor.SubstanceXtractor;
 import org.junit.jupiter.api.Test;
+import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.io.MDLV3000Reader;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 public class IntegrationTest {
@@ -228,6 +233,43 @@ public class IntegrationTest {
       assertEquals(expectedInChIs[i], subs.get(i).getInchi());
       assertEquals(expectedInChIKeys[i], subs.get(i).getInchiKey());
       assertEquals(expectedSmiles[i], subs.get(i).getSmiles());
+    }
+  }
+
+  @Test
+  public void mdlV3000TetrahedralStereoRoundTripTest() throws IOException, CDKException {
+    // Regression guard for the MDL V3000 wedge-bond fix (SubstanceXtractor.withWedgeBonds).
+    // CDK's MDLV3000Reader ignores the atom parity (CFG) field for structures with 2D coordinates
+    // and re-perceives tetrahedral stereo from wedge/hash bonds only. When the stereo comes from
+    // perception rather than drawn wedges the extractor's container carries ITetrahedralChirality
+    // elements but no wedge bonds, so without wedge assignment the round-tripped mol file drops its
+    // stereo layer (…-UHFFFAOYSA-…) even though getInchiKey() and getSmiles() retain it. These
+    // sugar fixtures reproduce exactly that loss; each expected key carries a real stereo layer.
+    record Fixture(String path, String expectedKey) {}
+    Fixture[] fixtures = {
+      new Fixture("sugars/bond_down_SRRSR.cdx", "WQZGKKKJIJFFOK-UKFBFLRUSA-N"),
+      new Fixture("sugars/bond_up_SRSSR.cdx", "WQZGKKKJIJFFOK-DVKNGEFBSA-N"),
+    };
+    for (Fixture fixture : fixtures) {
+      InputStream in =
+          IntegrationTest.class.getResourceAsStream("/integrationTests/" + fixture.path());
+      assertNotNull(in, fixture.path());
+      CDDocument document = CDXReader.readDocument(in);
+      assertNotNull(document, fixture.path());
+
+      SubstanceXtractor xtractor = new SubstanceXtractor(SilentChemObjectBuilder.getInstance());
+      List<BCXSubstance> subs = xtractor.xtract(document, new BCXSubstanceInfo(), false);
+      assertFalse(subs.isEmpty(), fixture.path());
+
+      BCXSubstance sub = subs.get(0);
+      assertEquals(fixture.expectedKey(), sub.getInchiKey(), fixture.path() + ": direct InChIKey");
+      MDLV3000Reader reader = new MDLV3000Reader(new StringReader(sub.getMdlv3000()));
+      IAtomContainer molFileAc = reader.readMolecule(SilentChemObjectBuilder.getInstance());
+      String molFileKey = ChemicalUtils.getInChI(molFileAc).getInchiKey();
+      assertEquals(
+          fixture.expectedKey(),
+          molFileKey,
+          fixture.path() + ": MDL V3000 round-trip must preserve stereo");
     }
   }
 


### PR DESCRIPTION
## Problem

The MDL V3000 mol file written into `BCXSubstance.getMdlv3000()` silently loses tetrahedral stereochemistry on round-trip: the re-parsed structure's InChIKey drops its stereo layer (`…-UHFFFAOYSA-…`) even though `getInchiKey()` and `getSmiles()` (which use the stereo elements directly) retain it.

## Root cause

CDK's `MDLV3000Reader` **deliberately ignores the atom parity (`CFG`) field for structures with 2D coordinates** and re-perceives tetrahedral stereo from **wedge/hash bonds only**. When the extractor's stereo comes from perception (not drawn wedges), the container holds `ITetrahedralChirality` elements but **no wedge bonds**, so `MDLV3000Writer` encodes the stereo only as atom `CFG` — which the reader then discards.

## Fix

`SubstanceXtractor.withWedgeBonds` assigns wedge bonds from the stereo elements via `StructureDiagramGenerator.generateWedges` (a public wrapper over `NonplanarBonds.assign` that does not relayout) before writing the mol file. Wedges are assigned on a **clone**, so the shared container used for SMILES/InChI generation and exposed via `getAtomContainer()` is untouched. If cloning or wedge assignment fails, the original container is written, preserving previous behaviour.

## Test

Adds `IntegrationTest.mdlV3000TetrahedralStereoRoundTripTest` using the committed sugar fixtures (`bond_down_SRRSR`, `bond_up_SRSSR`), asserting the MDL V3000 round-trip preserves the stereo layer. Verified the test fails on the pre-fix code (`…-UHFFFAOYSA-…`) and passes after the fix.

## Verification

- Full suite green (the only local failures are pre-existing `volumeTest` cases whose gitignored fixtures aren't checked in).
- `mvn spotless:apply` clean.

## Scope note

This addresses tetrahedral stereo lost via the MDL writer. A separate, unrelated class of stereo divergence — double bonds drawn with a wavy ("E/Z unspecified") substituent, where SMILES honours the wavy while InChI/MDL assign E/Z from coordinates — is a chemistry-intent decision and is **not** part of this PR.