### PR TITLE
fix: Markush R-group extraction fixes (batch)

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/utils/MarkushHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/MarkushHandler.java
@@ -39,6 +39,7 @@ import org.beilstein.chemxtract.visitor.CorrelatedGroup;
 import org.beilstein.chemxtract.visitor.RGroupDefinitionBlock;
 import org.beilstein.chemxtract.visitor.TextVisitor;
 import org.openscience.cdk.Bond;
+import org.openscience.cdk.config.Elements;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.interfaces.IAtom;
@@ -318,15 +319,23 @@ public class MarkushHandler {
 
   /**
    * Resolves a substituent definition to a SMILES string, looking up abbreviations if the
-   * definition matches a known alias.
+   * definition matches a known alias, and bracketing bare element symbols that fall outside the
+   * SMILES organic subset (e.g. {@code Se}, {@code Te}) so they parse.
    *
    * @param definition a SMILES string or a known abbreviation
    * @return the resolved SMILES string
    */
   private String resolveSmiles(String definition) throws IOException {
-    return SmilesAbbreviations.contains(definition)
-        ? SmilesAbbreviations.get(definition)
-        : definition;
+    if (SmilesAbbreviations.contains(definition)) {
+      return SmilesAbbreviations.get(definition);
+    }
+    // A bare element symbol outside the SMILES organic subset (Se, Te, Si, ...) is not valid SMILES
+    // on its own; wrap it in brackets so it parses as that atom.
+    if (!ChemicalUtils.isValidSmiles(definition)
+        && Elements.ofString(definition) != Elements.Unknown) {
+      return "[" + definition + "]";
+    }
+    return definition;
   }
 
   /**

--- a/src/test/java/org/beilstein/chemxtract/utils/MarkushHandlerTest.java
+++ b/src/test/java/org/beilstein/chemxtract/utils/MarkushHandlerTest.java
@@ -28,8 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.vecmath.Point2d;
 import org.beilstein.chemxtract.cdx.CDAtom;
 import org.beilstein.chemxtract.cdx.CDDocument;
@@ -196,6 +198,48 @@ public class MarkushHandlerTest {
     List<IAtomContainer> results = handler.replaceRGroups(scaffold, rect(0, 0, 40, 40));
 
     assertEquals(3, results.size(), "one structure per table row, no (F,F) corner");
+  }
+
+  /**
+   * A placeholder whose substituents are bare element symbols outside the SMILES organic subset
+   * (Se, Te) must still resolve — they need bracketing to parse. Y = S, Se, Te yields all three.
+   */
+  @Test
+  public void bareNonOrganicElementSubstituentsResolve()
+      throws IOException, CloneNotSupportedException, CDKException {
+    CDPage page = new CDPage();
+    page.addText(textAt(rect(0, 0, 50, 50), "Y = S, Se, Te"));
+    MarkushHandler handler = new MarkushHandler(page, SilentChemObjectBuilder.getInstance());
+
+    // Scaffold: C0-Y-C1 (Y is a divalent bridge, like a chalcogen in a ring).
+    IChemObjectBuilder builder = SilentChemObjectBuilder.getInstance();
+    IAtomContainer scaffold = builder.newAtomContainer();
+    IAtom c0 = builder.newInstance(IAtom.class, "C");
+    c0.setPoint2d(new Point2d(0.0, 0.0));
+    IPseudoAtom y = builder.newInstance(IPseudoAtom.class, "Y");
+    y.setLabel("Y");
+    y.setPoint2d(new Point2d(1.5, 0.0));
+    IAtom c1 = builder.newInstance(IAtom.class, "C");
+    c1.setPoint2d(new Point2d(3.0, 0.0));
+    scaffold.addAtom(c0);
+    scaffold.addAtom(y);
+    scaffold.addAtom(c1);
+    scaffold.addBond(0, 1, IBond.Order.SINGLE);
+    scaffold.addBond(1, 2, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results = handler.replaceRGroups(scaffold, rect(0, 0, 40, 40));
+
+    assertEquals(3, results.size(), "S, Se and Te must all resolve");
+    Set<Integer> chalcogens = new HashSet<>();
+    for (IAtomContainer product : results) {
+      for (IAtom atom : product.atoms()) {
+        Integer z = atom.getAtomicNumber();
+        if (z != null && (z == 16 || z == 34 || z == 52)) {
+          chalcogens.add(z);
+        }
+      }
+    }
+    assertEquals(Set.of(16, 34, 52), chalcogens, "expected S (16), Se (34) and Te (52)");
   }
 
   private static List<String> rLabelsOf(CDFragment fragment) {


### PR DESCRIPTION
Batch of follow-up fixes to Markush R-group extraction (after #97). Each is an independent, TDD'd fix committed to this branch.

## Fixes in this PR

- [x] **Bare non-organic-subset element R-groups** (`Se`, `Te`, `Si`, …) — these failed `isValidSmiles` and were silently dropped (e.g. `Y = S, Se, Te` only produced `S`). `MarkushHandler.resolveSmiles` now brackets them (`[Se]`, `[Te]`). Fixture: `mantis11158/20-30-i8.cdx` (15 → 21 unique). Test: `MarkushHandlerTest.bareNonOrganicElementSubstituentsResolve`.

_(more fixes will be appended as further fixtures are reviewed)_

## Status

Full suite green; Spotless clean.