### PR TITLE
feat: flag substances originating from Markush R-group expansion

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/model/BCXSubstance.java
+++ b/src/main/java/org/beilstein/chemxtract/model/BCXSubstance.java
@@ -76,6 +76,9 @@ public class BCXSubstance implements Serializable {
    */
   private Map<String, String> abbreviations = new HashMap<String, String>();
 
+  /** True if this substance was enumerated from a Markush structure by R-group replacement. */
+  private boolean isMarkush = false;
+
   public BCXSubstance() {
     super();
   }
@@ -163,6 +166,14 @@ public class BCXSubstance implements Serializable {
 
   public void addAbbreviation(String smiles, String label) {
     this.abbreviations.put(smiles, label);
+  }
+
+  public boolean isMarkush() {
+    return isMarkush;
+  }
+
+  public void setMarkush(boolean isMarkush) {
+    this.isMarkush = isMarkush;
   }
 
   public String getMdlv3000() {

--- a/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
+++ b/src/main/java/org/beilstein/chemxtract/xtractor/SubstanceXtractor.java
@@ -309,7 +309,7 @@ public class SubstanceXtractor {
         try {
           for (IAtomContainer container :
               markushHandler.replaceRGroups(atomContainer, fragment.getBounds())) {
-            addIfBuilt(substances, container, fragment, variablePosition);
+            addIfBuilt(substances, container, fragment, variablePosition, true);
           }
           expandedRGroups = true;
         } catch (IOException | CloneNotSupportedException e) {
@@ -317,7 +317,7 @@ public class SubstanceXtractor {
         }
       }
       if (!expandedRGroups) {
-        addIfBuilt(substances, atomContainer, fragment, variablePosition);
+        addIfBuilt(substances, atomContainer, fragment, variablePosition, false);
       }
     }
     return substances;
@@ -331,6 +331,7 @@ public class SubstanceXtractor {
    * @param fragment the source fragment providing occurrence bounds and abbreviations
    * @param tolerateMissingInchi when {@code true}, a substance whose unresolved pseudo-atoms
    *     prevent InChI generation is still produced (carrying SMILES and molecular formula)
+   * @param isMarkush when {@code true}, the substance results from Markush R-group replacement
    * @return the populated {@link BCXSubstance}
    * @throws IOException if abbreviation resolution fails
    * @throws CDKException if InChI generation or nested fragment conversion fails
@@ -339,10 +340,12 @@ public class SubstanceXtractor {
       List<BCXSubstance> substances,
       IAtomContainer atomContainer,
       CDFragment fragment,
-      boolean tolerateMissingInchi)
+      boolean tolerateMissingInchi,
+      boolean isMarkush)
       throws IOException, CDKException {
     BCXSubstance substance = buildSubstance(atomContainer, fragment, tolerateMissingInchi);
     if (substance != null) {
+      substance.setMarkush(isMarkush);
       substances.add(substance);
     }
   }


### PR DESCRIPTION
## What

Adds an `isMarkush` flag to `BCXSubstance` so callers can tell enumerated Markush variants apart from structures drawn explicitly on the page.

- `BCXSubstance.isMarkush` — `boolean`, defaults to `false`, with `isMarkush()` / `setMarkush(boolean)`.
- Set to `true` only for substances emitted by the `MarkushHandler.replaceRGroups(...)` branch of `SubstanceXtractor.xtractSubstances`; the non-expanded path passes `false`.
- The flag is threaded through the existing private `addIfBuilt(...)` helper, so both call sites state their origin explicitly.

## Notes

- `serialVersionUID` is deliberately **unchanged**. Adding a non-transient field is a compatible change under Java serialization: existing serialized payloads still deserialize, with the new flag defaulting to `false`. Bumping it would have turned old payloads into `InvalidClassException`.
- `equals`/`hashCode`/`toString` untouched — substance identity remains the InChIKey.
- No new test: the flag is currently only set, never branched on. Worth a fixture assertion once something downstream consumes it.

## Verification

`mvn -B -o test` → BUILD SUCCESS, 369 tests, 0 failures, 0 errors, 15 skipped (the pre-existing `@Disabled` ones). `mvn spotless:apply` run before committing.