### PR TITLE
fix: keep both attachments when substituting a bivalent Markush residue

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/utils/ChemicalUtils.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/ChemicalUtils.java
@@ -210,11 +210,28 @@ public class ChemicalUtils {
    * @return The nearest residue atom to the given residueAtom.
    */
   public static IAtom findNearestResidueAtom(IAtom residueAtom, IAtomContainer atomContainer) {
+    return findNearestResidueAtom(residueAtom, atomContainer, null);
+  }
+
+  /**
+   * Finds the nearest residue atom to the given residueAtom within the provided AtomContainer,
+   * optionally restricted to residues carrying a given label.
+   *
+   * @param residueAtom reference residue atom
+   * @param atomContainer AtomContainer in which to search for the nearest residue atom.
+   * @param label when not {@code null}, only pseudo-atoms with this label are considered; a caller
+   *     pairing up two halves of one R-group must not pick up an unrelated residue
+   * @return The nearest residue atom to the given residueAtom.
+   */
+  public static IAtom findNearestResidueAtom(
+      IAtom residueAtom, IAtomContainer atomContainer, String label) {
     IAtom nearestResidueAtom = null;
     int dist = Integer.MAX_VALUE;
     ShortestPaths path = new ShortestPaths(atomContainer, residueAtom);
     for (IAtom atom : atomContainer.atoms()) {
-      if (atom instanceof IPseudoAtom && atom != residueAtom) {
+      if (atom instanceof IPseudoAtom pseudoAtom
+          && atom != residueAtom
+          && (label == null || label.equals(pseudoAtom.getLabel()))) {
         int pathDist = path.distanceTo(atom);
         if (pathDist < dist) {
           dist = pathDist;

--- a/src/main/java/org/beilstein/chemxtract/utils/MarkushHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/MarkushHandler.java
@@ -912,10 +912,18 @@ public class MarkushHandler {
 
       List<IAtom> pseudos = new ArrayList<>();
       pseudos.add(pseudoAtom);
-      IAtom nearestOtherResidue = ChemicalUtils.findNearestResidueAtom(pseudoAtom, atomContainer);
-      if (nearestOtherResidue != null) {
-        visitedAtoms.add(nearestOtherResidue);
-        pseudos.add(nearestOtherResidue);
+      // A pseudo-atom that already carries two bonds *is* the bivalent position — a ring member or
+      // a chain link — and its own two bonds are the attachment points. Only a monovalent residue
+      // needs a partner to bridge to, and that partner must carry the same label: the nearest
+      // pseudo-atom of any label would swallow an unrelated R-group and silently drop its
+      // substituent.
+      if (atomContainer.getConnectedBondsCount(pseudoAtom) < 2) {
+        IAtom nearestOtherResidue =
+            ChemicalUtils.findNearestResidueAtom(pseudoAtom, atomContainer, residueKey);
+        if (nearestOtherResidue != null) {
+          visitedAtoms.add(nearestOtherResidue);
+          pseudos.add(nearestOtherResidue);
+        }
       }
 
       reconnectResidue(atomContainer, extendedClone, pseudos, bondsToRemove, atomsToRemove);
@@ -929,7 +937,10 @@ public class MarkushHandler {
   }
 
   /**
-   * Reconnects substituted residues to the original atom container.
+   * Reconnects substituted residues to the original atom container. Every bond of every replaced
+   * pseudo-atom is one attachment, so a single bivalent residue (a ring member or chain link)
+   * contributes both of its bonds while two monovalent residues contribute one each. Attachments
+   * are wired to the substituent's connection points in order.
    *
    * @param atomContainer original molecule
    * @param extendedStructure substituted structure
@@ -943,23 +954,39 @@ public class MarkushHandler {
       List<IAtom> pseudoAtoms,
       Set<IBond> bondsToRemove,
       Set<IAtom> atomsToRemove) {
-    atomContainer.add(extendedStructure);
-    List<IAtom> connectionPoints = new ArrayList<>();
+    record Attachment(IAtom residue, IBond bond) {}
 
+    List<IAtom> connectionPoints = new ArrayList<>();
     for (IAtom smilesAtom : extendedStructure.atoms()) {
       if (smilesAtom instanceof IPseudoAtom) {
         connectionPoints.add(smilesAtom);
       }
     }
-    for (int i = 0; i < pseudoAtoms.size(); i++) {
-      IAtom rAtom = pseudoAtoms.get(i);
-      IBond bondOrigin = rAtom.bonds().iterator().next();
+    List<Attachment> attachments = new ArrayList<>();
+    for (IAtom rAtom : pseudoAtoms) {
+      rAtom.bonds().forEach(bond -> attachments.add(new Attachment(rAtom, bond)));
+    }
+    if (attachments.size() != connectionPoints.size()) {
+      // Wiring only some of the attachments would drop a bond and silently open a ring or split
+      // the molecule. Leaving the pseudo-atom in place instead keeps the structure out of the
+      // output, since SubstanceXtractor skips structures with unresolved pseudo-atoms.
+      LOGGER.warn(
+          "Residue has {} attachment(s) but its substituent offers {} connection point(s);"
+              + " leaving the R-group unsubstituted.",
+          attachments.size(),
+          connectionPoints.size());
+      return;
+    }
+
+    atomContainer.add(extendedStructure);
+    for (int i = 0; i < attachments.size(); i++) {
+      IAtom rAtom = attachments.get(i).residue();
+      IBond bondOrigin = attachments.get(i).bond();
       IAtom atomOrigin = bondOrigin.getOther(rAtom);
       IAtom conPoint = connectionPoints.get(i);
       IBond bondAbbr = conPoint.bonds().iterator().next();
       IAtom atomAbbr = bondAbbr.getOther(conPoint);
-      IBond bond = new Bond(atomOrigin, atomAbbr, rAtom.bonds().iterator().next().getOrder());
-      atomContainer.addBond(bond);
+      atomContainer.addBond(new Bond(atomOrigin, atomAbbr, bondOrigin.getOrder()));
       bondsToRemove.add(bondOrigin);
       bondsToRemove.add(bondAbbr);
       atomsToRemove.add(rAtom);

--- a/src/test/java/org/beilstein/chemxtract/utils/MarkushHandlerTest.java
+++ b/src/test/java/org/beilstein/chemxtract/utils/MarkushHandlerTest.java
@@ -24,6 +24,7 @@ package org.beilstein.chemxtract.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -37,6 +38,8 @@ import org.beilstein.chemxtract.cdx.CDText;
 import org.beilstein.chemxtract.cdx.datatypes.CDStyledString;
 import org.junit.jupiter.api.Test;
 import org.openscience.cdk.exception.CDKException;
+import org.openscience.cdk.graph.ConnectivityChecker;
+import org.openscience.cdk.graph.Cycles;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
@@ -278,5 +281,223 @@ public class MarkushHandlerTest {
 
     assertEquals(List.of("Cl"), handler.residueLabelsNear(rect(0, 0, 40, 40)).get("R"));
     assertEquals(List.of("Br"), handler.residueLabelsNear(rect(210, 0, 240, 40)).get("R"));
+  }
+
+  /** Scaffold atom with 2D coordinates at the given x, on the y = 0 axis. */
+  private static IAtom carbonAt(double x) {
+    IAtom atom = SilentChemObjectBuilder.getInstance().newInstance(IAtom.class, "C");
+    atom.setPoint2d(new Point2d(x, 0.0));
+    return atom;
+  }
+
+  /** Pseudo-atom (R-group placeholder) with 2D coordinates at the given x. */
+  private static IPseudoAtom residueAt(String label, double x) {
+    IPseudoAtom atom = SilentChemObjectBuilder.getInstance().newInstance(IPseudoAtom.class, label);
+    atom.setLabel(label);
+    atom.setPoint2d(new Point2d(x, 0.0));
+    return atom;
+  }
+
+  /** Handler with structural definitions only, so substituent SMILES bypass legend parsing. */
+  private static MarkushHandler handlerWith(Map<String, List<String>> definitions) {
+    MarkushHandler handler =
+        new MarkushHandler(new CDPage(), SilentChemObjectBuilder.getInstance());
+    handler.addResidueDefinitions(definitions);
+    return handler;
+  }
+
+  private static void assertNoPseudoAtoms(IAtomContainer product) {
+    for (IAtom atom : product.atoms()) {
+      assertFalse(atom instanceof IPseudoAtom, "no pseudo-atom may survive substitution");
+    }
+  }
+
+  /**
+   * A residue drawn as a chain link carries two bonds, and a two-attachment substituent must keep
+   * both: wiring only the first bond leaves the molecule cut in two.
+   */
+  @Test
+  public void bivalentResidueInChainKeepsBothConnections()
+      throws IOException, CloneNotSupportedException, CDKException {
+    // Scaffold: C0-X-C1, X bivalent.
+    IAtomContainer scaffold = SilentChemObjectBuilder.getInstance().newAtomContainer();
+    scaffold.addAtom(carbonAt(0.0));
+    scaffold.addAtom(residueAt("X", 1.5));
+    scaffold.addAtom(carbonAt(3.0));
+    scaffold.addBond(0, 1, IBond.Order.SINGLE);
+    scaffold.addBond(1, 2, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results =
+        handlerWith(Map.of("X", List.of("[*]C[*]"))).replaceRGroups(scaffold);
+
+    assertEquals(1, results.size());
+    IAtomContainer product = results.get(0);
+    assertEquals(3, product.getAtomCount(), "two scaffold carbons plus the bridging carbon");
+    assertEquals(2, product.getBondCount(), "both original bonds must be re-made");
+    assertEquals(
+        1,
+        ConnectivityChecker.partitionIntoMolecules(product).getAtomContainerCount(),
+        "the chain must stay in one piece");
+    assertNoPseudoAtoms(product);
+  }
+
+  /**
+   * A residue drawn as a ring member must not open the ring: both of its bonds are attachment
+   * points for the two-attachment substituent.
+   */
+  @Test
+  public void bivalentResidueInRingKeepsRingClosed()
+      throws IOException, CloneNotSupportedException, CDKException {
+    // Scaffold: five carbons plus X closing a six-membered ring.
+    IAtomContainer scaffold = SilentChemObjectBuilder.getInstance().newAtomContainer();
+    for (int i = 0; i < 5; i++) {
+      scaffold.addAtom(carbonAt(i * 1.5));
+    }
+    scaffold.addAtom(residueAt("X", 7.5));
+    for (int i = 0; i < 5; i++) {
+      scaffold.addBond(i, i + 1, IBond.Order.SINGLE);
+    }
+    scaffold.addBond(5, 0, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results =
+        handlerWith(Map.of("X", List.of("[*]C[*]"))).replaceRGroups(scaffold);
+
+    assertEquals(1, results.size());
+    IAtomContainer product = results.get(0);
+    assertEquals(6, product.getAtomCount());
+    assertEquals(6, product.getBondCount(), "ring bond count is preserved");
+    assertEquals(1, Cycles.mcb(product).numberOfCycles(), "the ring must stay closed");
+    assertNoPseudoAtoms(product);
+  }
+
+  /**
+   * The layout a two-attachment substituent was written for: two monovalent residues of the same
+   * label, bridged by one substituent. Regression guard for the bivalent fix.
+   */
+  @Test
+  public void twoMonovalentResiduesAreBridgedByOneSubstituent()
+      throws IOException, CloneNotSupportedException, CDKException {
+    // Scaffold: X-C0-C1-C2-X, both X monovalent, bridged into a four-membered ring.
+    IAtomContainer scaffold = SilentChemObjectBuilder.getInstance().newAtomContainer();
+    scaffold.addAtom(carbonAt(0.0));
+    scaffold.addAtom(carbonAt(1.5));
+    scaffold.addAtom(carbonAt(3.0));
+    scaffold.addAtom(residueAt("X", -1.5));
+    scaffold.addAtom(residueAt("X", 4.5));
+    scaffold.addBond(0, 1, IBond.Order.SINGLE);
+    scaffold.addBond(1, 2, IBond.Order.SINGLE);
+    scaffold.addBond(0, 3, IBond.Order.SINGLE);
+    scaffold.addBond(2, 4, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results =
+        handlerWith(Map.of("X", List.of("[*]C[*]"))).replaceRGroups(scaffold);
+
+    assertEquals(1, results.size());
+    IAtomContainer product = results.get(0);
+    assertEquals(4, product.getAtomCount(), "three scaffold carbons plus the bridge");
+    assertEquals(4, product.getBondCount());
+    assertEquals(1, Cycles.mcb(product).numberOfCycles(), "the bridge closes one ring");
+    assertNoPseudoAtoms(product);
+  }
+
+  /**
+   * A bivalent residue must not steal an unrelated R-group as its second attachment point: doing so
+   * consumed the foreign residue and dropped its substituent entirely.
+   */
+  @Test
+  public void bivalentResidueDoesNotConsumeForeignLabel()
+      throws IOException, CloneNotSupportedException, CDKException {
+    // Scaffold: C0-X-C1-R1, X bivalent, R1 a separate monovalent residue.
+    IAtomContainer scaffold = SilentChemObjectBuilder.getInstance().newAtomContainer();
+    scaffold.addAtom(carbonAt(0.0));
+    scaffold.addAtom(residueAt("X", 1.5));
+    scaffold.addAtom(carbonAt(3.0));
+    scaffold.addAtom(residueAt("R1", 4.5));
+    scaffold.addBond(0, 1, IBond.Order.SINGLE);
+    scaffold.addBond(1, 2, IBond.Order.SINGLE);
+    scaffold.addBond(2, 3, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results =
+        handlerWith(Map.of("X", List.of("[*]C[*]"), "R1", List.of("Cl"))).replaceRGroups(scaffold);
+
+    assertEquals(1, results.size());
+    IAtomContainer product = results.get(0);
+    assertEquals(4, product.getAtomCount(), "three carbons plus the chlorine");
+    assertEquals(3, product.getBondCount());
+    assertEquals(
+        1,
+        ConnectivityChecker.partitionIntoMolecules(product).getAtomContainerCount(),
+        "R1 must still be attached, not consumed as X's second attachment point");
+    boolean hasChlorine = false;
+    for (IAtom atom : product.atoms()) {
+      Integer z = atom.getAtomicNumber();
+      if (z != null && z == 17) {
+        hasChlorine = true;
+      }
+    }
+    assertTrue(hasChlorine, "the foreign residue's own substituent must survive");
+    assertNoPseudoAtoms(product);
+  }
+
+  /**
+   * When the residue's valence and the substituent's connection points disagree, the R-group is
+   * left unsubstituted rather than grafted with a dropped bond — SubstanceXtractor then skips the
+   * structure instead of emitting a mis-connected one.
+   */
+  @Test
+  public void attachmentCountMismatchLeavesResidueUnsubstituted()
+      throws IOException, CloneNotSupportedException, CDKException {
+    // Scaffold: X bonded to three carbons, substituent offers only two connection points.
+    IAtomContainer scaffold = SilentChemObjectBuilder.getInstance().newAtomContainer();
+    scaffold.addAtom(residueAt("X", 0.0));
+    scaffold.addAtom(carbonAt(1.5));
+    scaffold.addAtom(carbonAt(3.0));
+    scaffold.addAtom(carbonAt(4.5));
+    scaffold.addBond(0, 1, IBond.Order.SINGLE);
+    scaffold.addBond(0, 2, IBond.Order.SINGLE);
+    scaffold.addBond(0, 3, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results =
+        handlerWith(Map.of("X", List.of("[*]C[*]"))).replaceRGroups(scaffold);
+
+    assertEquals(1, results.size());
+    IAtomContainer product = results.get(0);
+    assertEquals(4, product.getAtomCount(), "nothing may be grafted");
+    assertEquals(3, product.getBondCount(), "no bond may be lost");
+    long pseudoAtoms = 0;
+    for (IAtom atom : product.atoms()) {
+      if (atom instanceof IPseudoAtom) {
+        pseudoAtoms++;
+      }
+    }
+    assertEquals(1, pseudoAtoms, "the unresolvable residue stays in place");
+  }
+
+  /**
+   * A single-atom definition on a bivalent residue (X = O in a ring) goes through the
+   * single-attachment path, which rewires every bond of the residue. Guards the common case that
+   * already worked.
+   */
+  @Test
+  public void singleAtomDefinitionOnBivalentResidueKeepsRingClosed()
+      throws IOException, CloneNotSupportedException, CDKException {
+    IAtomContainer scaffold = SilentChemObjectBuilder.getInstance().newAtomContainer();
+    for (int i = 0; i < 5; i++) {
+      scaffold.addAtom(carbonAt(i * 1.5));
+    }
+    scaffold.addAtom(residueAt("X", 7.5));
+    for (int i = 0; i < 5; i++) {
+      scaffold.addBond(i, i + 1, IBond.Order.SINGLE);
+    }
+    scaffold.addBond(5, 0, IBond.Order.SINGLE);
+
+    List<IAtomContainer> results = handlerWith(Map.of("X", List.of("O"))).replaceRGroups(scaffold);
+
+    assertEquals(1, results.size());
+    IAtomContainer product = results.get(0);
+    assertEquals(6, product.getAtomCount());
+    assertEquals(6, product.getBondCount());
+    assertEquals(1, Cycles.mcb(product).numberOfCycles(), "the oxygen closes the ring");
+    assertNoPseudoAtoms(product);
   }
 }


### PR DESCRIPTION
## Problem

A residue drawn as a **ring member or chain link** carries two bonds, but `replaceDualBondedResidue` assumed two distinct pseudo-atoms to bridge, and `reconnectResidue` wired only `rAtom.bonds().iterator().next()` — the *first* bond of each. The second bond died with the removed pseudo-atom, silently opening the ring or splitting the molecule.

Measured on synthetic scaffolds (`X = [*]C[*]`):

| Scaffold | Before | Expected |
|---|---|---|
| chain `C–X–C` | `C.CC` — 2 fragments, 1 bond | `CCC` |
| six-ring with `X` in the ring | `CCCCCC` — ring opened, 5 bonds | `C1CCCCC1` |
| bivalent `X` + unrelated `R1 = Cl` | `CCC` — `R1` consumed, Cl lost | `CCCCl` |

The same breakage applies to the 16 two-star entries `abbreviations.smi` already ships (`SO2`, `NMe`, `NTs`, `–OCH2O–`, …); verified with `SO2` on both scaffolds. Live exposure in the corpus: `m28875650-i2.cdx` (`X = NMe, NBn, NBoc, O, t-Bu, Ph`) and `m25061280-graphical-abstract.cdx` (`X = OH, SH, NTs`) both define a **bivalent** `X`.

## Fix

- `reconnectResidue` treats **every bond of every replaced pseudo-atom** as an attachment: one bivalent residue contributes both of its bonds, two monovalent ones contribute one each. Attachments are collected before any mutation, then wired to the substituent's connection points in order.
- Mismatched counts (e.g. a trivalent residue against a two-attachment substituent) log a warning and return **before** touching the container. The R-group stays unsubstituted, so `SubstanceXtractor.buildSubstance` skips the structure instead of emitting one with a dropped bond.
- A partner residue is only sought for a *monovalent* pseudo-atom, and must carry the **same label**. `ChemicalUtils.findNearestResidueAtom` returned the nearest pseudo-atom of any label, so a bivalent `X` consumed an unrelated `R1` and dropped its substituent entirely. New label-aware overload; the existing two-arg signature delegates with `null`, so public behaviour is unchanged (it had no other callers).

Single-atom definitions (`X = O`, `S`, `NH`, `Se`) are untouched — they go through `replaceSingleAtom`, which already rewires every bond of the residue. That is also why `CH2` belongs in the dictionary as plain `C` rather than `[*]C[*]`: it adapts to the residue's valence (mono → CH₃, bi → CH₂, double bond → =CH₂).

## Tests

Six new cases in `MarkushHandlerTest`:

| Test | Guards |
|---|---|
| `bivalentResidueInChainKeepsBothConnections` | 3 atoms, 2 bonds, 1 fragment |
| `bivalentResidueInRingKeepsRingClosed` | 6 bonds, 1 ring |
| `twoMonovalentResiduesAreBridgedByOneSubstituent` | the layout the dual path was written for still works |
| `bivalentResidueDoesNotConsumeForeignLabel` | the foreign `R1`'s Cl survives |
| `attachmentCountMismatchLeavesResidueUnsubstituted` | nothing grafted, no bond lost, pseudo-atom retained |
| `singleAtomDefinitionOnBivalentResidueKeepsRingClosed` | the path that already worked |

Confirmed non-vacuous: reverting the two main-code files makes exactly four of them fail (`bonds 2→1`, `ring 6→5`, `atoms 4→3`, `bonds 3→1`); the two guard tests pass either way.

`mvn -B verify`: **380 tests, 0 failures, 15 skipped** (pre-existing `@Disabled`), Spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)