### PR TITLE
build: fetch abbreviations.smi from BChemLookup on every build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<java.version>17</java.version>
 		<source.encoding>UTF-8</source.encoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<bchemlookup.abbreviations.url>https://raw.githubusercontent.com/Beilstein-Institut/BChemLookup/main/abbreviations.smi</bchemlookup.abbreviations.url>
 	</properties>
 
 
@@ -130,6 +131,37 @@
 				<configuration>
 					<encoding>${source.encoding}</encoding>
 				</configuration>
+			</plugin>
+
+			<!-- abbreviations.smi is curated upstream in Beilstein-Institut/BChemLookup.
+			     On every build we fetch the current list and prepend it to the
+			     checked-in copy, which therefore serves two purposes: offline/CI
+			     fallback when the download fails (ignoreerrors), and home for
+			     entries not (yet) upstream. SMILESLookupReader uses putIfAbsent on
+			     the lowercased key, so on a duplicate key upstream wins. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>fetch-upstream-abbreviations</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<mkdir dir="${project.build.directory}/bchemlookup"/>
+								<get src="${bchemlookup.abbreviations.url}" dest="${project.build.directory}/bchemlookup/abbreviations.smi" usetimestamp="true" ignoreerrors="true" verbose="false"/>
+								<concat destfile="${project.build.outputDirectory}/org/beilstein/chemxtract/lookups/abbreviations.smi" encoding="UTF-8" outputencoding="UTF-8" fixlastline="true">
+									<fileset file="${project.build.directory}/bchemlookup/abbreviations.smi"/>
+									<fileset file="${project.basedir}/src/main/resources/org/beilstein/chemxtract/lookups/abbreviations.smi"/>
+								</concat>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
## What

`abbreviations.smi` is curated upstream in [Beilstein-Institut/BChemLookup](https://github.com/Beilstein-Institut/BChemLookup). Until now BChemXtract carried a copy-pasted snapshot in `src/main/resources` that had to be synced by hand — and had drifted in both directions.

`maven-antrun-plugin` now downloads the upstream list at `process-resources` and concatenates it **in front of** the checked-in copy into `target/classes`. `SMILESLookupReader` uses `putIfAbsent` on the lowercased key, so upstream wins on duplicates.

The checked-in file keeps two roles:
- **offline/CI fallback** — `<get>` runs with `ignoreerrors="true"`, so a failed download leaves the build green on the snapshot
- home for entries not (yet) upstream

## Notes

- The URL is exposed as the `bchemlookup.abbreviations.url` property, so a release build can pin it to a commit SHA for reproducibility: `-Dbchemlookup.abbreviations.url=https://raw.githubusercontent.com/Beilstein-Institut/BChemLookup/<sha>/abbreviations.smi`
- The 5 entries that existed only locally (`OMe-Ph`, `PhCONMe`, `PhCONH`, `PhCOO`, `NHMe`) were upstreamed in BChemLookup#9, so divergence is currently zero. They are deliberately left in the checked-in copy so `MarkushTest.testMarkush_Ar_X_Y` still passes on a network-less build.

## Verification

- online: upstream 301 lines + local 270 → 571 lines in `target/classes`
- bad URL: build succeeds, falls back to the 270-line snapshot
- `mvn -B test` → 380 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

