### PR TITLE
build(deps): bump CDK to 2.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
 
 	<properties>
-		<cdk.version>2.12</cdk.version>
+		<cdk.version>2.13</cdk.version>
 		<java.version>25</java.version>
 		<source.encoding>UTF-8</source.encoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

* Update to CDK 2.13

Rebase of @egonw's #117 onto current `main`. The original branch was cut before the Java 25 migration and before the 1.4.1 release, so it carried an unrelated `<version>` change and conflicted in the `<properties>` block. Rebased here with @egonw's authorship preserved; the diff is now the single `cdk.version` line.

Supersedes #117 and #123.

## Type of change

- [x] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [x] PR title follows Conventional Commits
- [ ] `mvn -B verify` passes locally
- [x] `mvn spotless:apply` was run (or `mvn spotless:check` is clean)
- [ ] New behavior is covered by tests
- [ ] Public API changes are documented (Javadoc + README/HOWTO if applicable)
