### PR TITLE
fix: bound and correct position-variation attachment handling

### DIFF
--- a/src/main/java/org/beilstein/chemxtract/utils/AttachmentHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/AttachmentHandler.java
@@ -30,6 +30,8 @@ import org.beilstein.chemxtract.cdx.CDFragment;
 import org.beilstein.chemxtract.cdx.datatypes.CDBondOrder;
 import org.beilstein.chemxtract.cdx.datatypes.CDNodeType;
 import org.beilstein.chemxtract.cdx.datatypes.CDPoint2D;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for resolving multi-center and variable attachment nodes within a {@link
@@ -57,6 +59,16 @@ import org.beilstein.chemxtract.cdx.datatypes.CDPoint2D;
  * single downstream expansion path handles both.
  */
 public final class AttachmentHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AttachmentHandler.class);
+
+  /**
+   * Upper bound on the number of position-variation isomers enumerated for a single fragment. The
+   * candidate choices of all variable attachment nodes in a fragment multiply, so a drawing with a
+   * handful of nodes can span billions of combinations - a generic depiction rather than an
+   * enumerable set of substances. Such a fragment is skipped instead of exhausting the heap.
+   */
+  private static final long MAX_VARIANTS = 1000L;
 
   private AttachmentHandler() {
     // private constructor to hide implicit public one
@@ -280,7 +292,8 @@ public final class AttachmentHandler {
    *
    * @param fragment the fragment to expand
    * @return the list of expanded fragments; the singleton list {@code [fragment]} when no variable
-   *     attachment node is present
+   *     attachment node is present, and an empty list when the combinations exceed {@link
+   *     #MAX_VARIANTS}
    */
   public static List<CDFragment> expandVariableAttachments(CDFragment fragment) {
     List<CDAtom> variableNodes =
@@ -310,6 +323,18 @@ public final class AttachmentHandler {
 
     if (points.isEmpty()) {
       return List.of(fragment);
+    }
+
+    long combinations = 1L;
+    for (VariablePoint point : points) {
+      combinations *= point.candidates().size();
+      if (combinations > MAX_VARIANTS) {
+        LOGGER.warn(
+            "Skipping fragment: {} variable attachment nodes enumerate more than {} isomers.",
+            points.size(),
+            MAX_VARIANTS);
+        return List.of();
+      }
     }
 
     // Atoms and bonds that are common to every variant: everything except the variable nodes and

--- a/src/main/java/org/beilstein/chemxtract/utils/AttachmentHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/AttachmentHandler.java
@@ -21,6 +21,7 @@
  */
 package org.beilstein.chemxtract.utils;
 
+import java.awt.geom.Line2D;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -70,6 +71,15 @@ public final class AttachmentHandler {
    */
   private static final long MAX_VARIANTS = 1000L;
 
+  /**
+   * How far a position-variation bond may stay clear of the bond it attaches to, as a fraction of
+   * that bond's length. ChemDraw's crossing-bond list is a drawing relationship and also names
+   * bonds the crossing bond never reaches, whose endpoints must not become attachment candidates.
+   * Across the reference corpus every real attachment closes to within 0.4 bond lengths of its
+   * crossed bond while unrelated pairs stay beyond 0.8.
+   */
+  private static final double MAX_ATTACHMENT_GAP = 0.5;
+
   private AttachmentHandler() {
     // private constructor to hide implicit public one
   }
@@ -92,6 +102,10 @@ public final class AttachmentHandler {
    * relationship after a merge, are both ignored (the scaffold endpoint is not a degree-one free
    * end, and the candidates then live in the fragment being inspected).
    *
+   * <p>A crossing reference only describes an attachment when the two bonds actually meet on the
+   * page (see {@link #reaches(CDBond, CDBond)}); bonds merely named by each other, as overlapping
+   * drawings are, contribute no candidates.
+   *
    * @param fragments the fragments collected from a page; mutated in place
    * @return the fragments to extract, with substituent fragments folded into their scaffolds
    */
@@ -105,6 +119,9 @@ public final class AttachmentHandler {
         }
         List<CDAtom> candidates = new ArrayList<>();
         for (CDBond c : crossed) {
+          if (!reaches(bond, c)) {
+            continue;
+          }
           addDistinct(candidates, c.getBegin());
           addDistinct(candidates, c.getEnd());
         }
@@ -134,6 +151,43 @@ public final class AttachmentHandler {
     List<CDFragment> result = new ArrayList<>(fragments);
     result.removeAll(merged);
     return result;
+  }
+
+  /**
+   * Whether the given bond reaches the bond it is said to cross: the two segments meet, or their
+   * gap stays within {@link #MAX_ATTACHMENT_GAP} of the crossed bond's length. A pair without
+   * coordinates is accepted, there being nothing to judge it by.
+   *
+   * @param bond the bond carrying the crossing reference
+   * @param crossed the bond it names
+   * @return {@code true} if the two are close enough to describe an attachment
+   */
+  private static boolean reaches(CDBond bond, CDBond crossed) {
+    CDPoint2D b1 = position(bond.getBegin());
+    CDPoint2D b2 = position(bond.getEnd());
+    CDPoint2D c1 = position(crossed.getBegin());
+    CDPoint2D c2 = position(crossed.getEnd());
+    if (b1 == null || b2 == null || c1 == null || c2 == null) {
+      return true;
+    }
+    Line2D bondLine = new Line2D.Float(b1.getX(), b1.getY(), b2.getX(), b2.getY());
+    Line2D crossedLine = new Line2D.Float(c1.getX(), c1.getY(), c2.getX(), c2.getY());
+    if (bondLine.intersectsLine(crossedLine)) {
+      return true;
+    }
+    double gap =
+        Math.min(
+            Math.min(
+                crossedLine.ptSegDist(b1.getX(), b1.getY()),
+                crossedLine.ptSegDist(b2.getX(), b2.getY())),
+            Math.min(
+                bondLine.ptSegDist(c1.getX(), c1.getY()),
+                bondLine.ptSegDist(c2.getX(), c2.getY())));
+    return gap <= MAX_ATTACHMENT_GAP * Math.hypot(c2.getX() - c1.getX(), c2.getY() - c1.getY());
+  }
+
+  private static CDPoint2D position(CDAtom atom) {
+    return atom == null ? null : atom.getPosition2D();
   }
 
   private static void addDistinct(List<CDAtom> atoms, CDAtom atom) {

--- a/src/main/java/org/beilstein/chemxtract/utils/AttachmentHandler.java
+++ b/src/main/java/org/beilstein/chemxtract/utils/AttachmentHandler.java
@@ -104,7 +104,9 @@ public final class AttachmentHandler {
    *
    * <p>A crossing reference only describes an attachment when the two bonds actually meet on the
    * page (see {@link #reaches(CDBond, CDBond)}); bonds merely named by each other, as overlapping
-   * drawings are, contribute no candidates.
+   * drawings are, contribute no candidates. A substituent moves to one scaffold and moves once,
+   * however many of its bonds cross it, so that several crossings mark several junctions rather
+   * than duplicating the substituent.
    *
    * @param fragments the fragments collected from a page; mutated in place
    * @return the fragments to extract, with substituent fragments folded into their scaffolds
@@ -112,6 +114,9 @@ public final class AttachmentHandler {
   public static List<CDFragment> normalizeVariableAttachmentBonds(List<CDFragment> fragments) {
     List<CDFragment> merged = new ArrayList<>();
     for (CDFragment sub : fragments) {
+      // The substituent's atoms and bonds move to its scaffold once, however many of its bonds
+      // carry a crossing reference; a second copy would duplicate the whole substituent.
+      CDFragment target = null;
       for (CDBond bond : new ArrayList<>(sub.getBonds())) {
         Set<CDBond> crossed = bond.getCrossingBonds();
         if (crossed == null || crossed.isEmpty()) {
@@ -135,14 +140,22 @@ public final class AttachmentHandler {
           continue;
         }
         CDFragment scaffold = fragmentContaining(fragments, candidates);
-        if (scaffold == null || scaffold == sub) {
+        // A scaffold that is itself a substituent has already moved elsewhere, and merging into it
+        // would discard these atoms with it; that chained drawing keeps its bond unresolved.
+        if (scaffold == null || scaffold == sub || merged.contains(scaffold)) {
+          continue;
+        }
+        if (target != null && target != scaffold) {
           continue;
         }
         attach.setNodeType(CDNodeType.VariableAttachment);
         attach.setAttachedAtoms(candidates);
-        scaffold.addAllAtoms(sub.getAtoms());
-        sub.getBonds().forEach(scaffold::addBond);
-        merged.add(sub);
+        if (target == null) {
+          target = scaffold;
+          scaffold.addAllAtoms(sub.getAtoms());
+          sub.getBonds().forEach(scaffold::addBond);
+          merged.add(sub);
+        }
       }
     }
     if (merged.isEmpty()) {

--- a/src/test/java/org/beilstein/chemxtract/utils/AttachmentHandlerTest.java
+++ b/src/test/java/org/beilstein/chemxtract/utils/AttachmentHandlerTest.java
@@ -24,6 +24,7 @@ package org.beilstein.chemxtract.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import org.beilstein.chemxtract.cdx.CDAtom;
 import org.beilstein.chemxtract.cdx.CDBond;
@@ -289,6 +290,38 @@ public class AttachmentHandlerTest {
       assertThat(variant.getAtoms()).doesNotContain(attach);
       assertThat(other(substituentBond(variant, substituent), substituent)).isIn(c1, c2);
     }
+  }
+
+  @Test
+  public void normalizeIgnoresCrossedBondsTheStubDoesNotReach() {
+    // Scaffold edge c1-c2, both endpoints further bonded so neither is a free end.
+    CDAtom c1 = element(0f, 0f);
+    CDAtom c2 = element(0f, 10f);
+    CDAtom x = element(-10f, 0f);
+    CDAtom y = element(-10f, 10f);
+    CDBond crossed = bond(c1, c2);
+    CDFragment scaffold = new CDFragment();
+    scaffold.setAtoms(List.of(c1, c2, x, y));
+    scaffold.setBonds(new ArrayList<>(List.of(crossed, bond(c1, x), bond(c2, y))));
+
+    // A bond that names the scaffold edge as crossed but is drawn two bond lengths clear of it -
+    // ChemDraw records such pairs, and their endpoints are no attachment candidates.
+    CDAtom near = element(20f, 5f);
+    CDAtom far = element(30f, 5f);
+    CDBond stub = bond(near, far);
+    stub.setCrossingBonds(new HashSet<>(List.of(crossed)));
+    crossed.setCrossingBonds(new HashSet<>(List.of(stub)));
+    CDFragment sub = new CDFragment();
+    sub.setAtoms(List.of(near, far));
+    sub.setBonds(new ArrayList<>(List.of(stub)));
+
+    List<CDFragment> result =
+        AttachmentHandler.normalizeVariableAttachmentBonds(new ArrayList<>(List.of(scaffold, sub)));
+
+    assertThat(result).containsExactly(scaffold, sub);
+    assertThat(near.getNodeType()).isEqualTo(CDNodeType.Element);
+    assertThat(near.getAttachedAtoms()).isNull();
+    assertThat(scaffold.getAtoms()).doesNotContain(near, far);
   }
 
   @Test

--- a/src/test/java/org/beilstein/chemxtract/utils/AttachmentHandlerTest.java
+++ b/src/test/java/org/beilstein/chemxtract/utils/AttachmentHandlerTest.java
@@ -227,6 +227,30 @@ public class AttachmentHandlerTest {
   }
 
   @Test
+  public void expandVariableAttachmentsSkipsFragmentsBeyondTheCombinationLimit() {
+    // 12 variable nodes with three candidates each multiply out to 531441 isomers - far past what
+    // a drawing can mean, and enough to exhaust the heap when enumerated.
+    CDFragment fragment = new CDFragment();
+    List<CDAtom> atoms = new ArrayList<>();
+    List<CDBond> bonds = new ArrayList<>();
+    for (int i = 0; i < 12; i++) {
+      CDAtom substituent = element();
+      CDAtom c1 = element();
+      CDAtom c2 = element();
+      CDAtom c3 = element();
+      CDAtom node = new CDAtom();
+      node.setNodeType(CDNodeType.VariableAttachment);
+      node.setAttachedAtoms(List.of(c1, c2, c3));
+      atoms.addAll(List.of(substituent, c1, c2, c3, node));
+      bonds.add(bond(node, substituent));
+    }
+    fragment.setAtoms(atoms);
+    fragment.setBonds(bonds);
+
+    assertThat(AttachmentHandler.expandVariableAttachments(fragment)).isEmpty();
+  }
+
+  @Test
   public void normalizeConvertsCrossingBondIntoVariableAttachmentAndMergesFragments() {
     // Scaffold: a two-atom "ring" edge c1-c2, each further bonded so both have degree >= 2.
     CDAtom c1 = element(0f, 0f);

--- a/src/test/java/org/beilstein/chemxtract/utils/AttachmentHandlerTest.java
+++ b/src/test/java/org/beilstein/chemxtract/utils/AttachmentHandlerTest.java
@@ -325,6 +325,49 @@ public class AttachmentHandlerTest {
   }
 
   @Test
+  public void normalizeMovesASubstituentWithSeveralCrossingBondsOnlyOnce() {
+    // Scaffold: a four-ring whose left (c1-c2) and right (c3-c4) edges are both crossed.
+    CDAtom c1 = element(0f, 0f);
+    CDAtom c2 = element(0f, 10f);
+    CDAtom c3 = element(20f, 0f);
+    CDAtom c4 = element(20f, 10f);
+    CDBond left = bond(c1, c2);
+    CDBond right = bond(c3, c4);
+    CDFragment scaffold = new CDFragment();
+    scaffold.setAtoms(List.of(c1, c2, c3, c4));
+    scaffold.setBonds(new ArrayList<>(List.of(left, right, bond(c2, c4), bond(c1, c3))));
+
+    // One substituent chain, drawn across both edges: each of its two bonds crosses one edge.
+    CDAtom endLeft = element(-2f, 5f);
+    CDAtom middle = element(10f, 5f);
+    CDAtom endRight = element(22f, 5f);
+    CDBond toLeft = bond(endLeft, middle);
+    CDBond toRight = bond(middle, endRight);
+    toLeft.setCrossingBonds(new HashSet<>(List.of(left)));
+    toRight.setCrossingBonds(new HashSet<>(List.of(right)));
+    left.setCrossingBonds(new HashSet<>(List.of(toLeft)));
+    right.setCrossingBonds(new HashSet<>(List.of(toRight)));
+    CDFragment sub = new CDFragment();
+    sub.setAtoms(List.of(endLeft, middle, endRight));
+    sub.setBonds(new ArrayList<>(List.of(toLeft, toRight)));
+
+    List<CDFragment> result =
+        AttachmentHandler.normalizeVariableAttachmentBonds(new ArrayList<>(List.of(scaffold, sub)));
+
+    // Both free ends become junctions, but the substituent's atoms and bonds move across once.
+    assertThat(result).containsExactly(scaffold);
+    assertThat(scaffold.getAtoms()).containsExactly(c1, c2, c3, c4, endLeft, middle, endRight);
+    assertThat(scaffold.getBonds()).hasSize(6);
+    assertThat(endLeft.getNodeType()).isEqualTo(CDNodeType.VariableAttachment);
+    assertThat(endLeft.getAttachedAtoms()).containsExactlyInAnyOrder(c1, c2);
+    assertThat(endRight.getNodeType()).isEqualTo(CDNodeType.VariableAttachment);
+    assertThat(endRight.getAttachedAtoms()).containsExactlyInAnyOrder(c3, c4);
+
+    // Two junctions with two candidates each -> the four position isomers, no duplicated atoms.
+    assertThat(AttachmentHandler.expandVariableAttachments(scaffold)).hasSize(4);
+  }
+
+  @Test
   public void normalizeLeavesFragmentsWithoutCrossingBondsUntouched() {
     CDAtom a = element(0f, 0f);
     CDAtom b = element(0f, 10f);


### PR DESCRIPTION
Position-variation extraction ran out of memory on two reported files, `volumeTest/vol20Test/m28096433-1.cdx` and `m28096433-4.cdx`. Three defects, each with its own commit and unit test.

## 1. Unbounded enumeration (the OutOfMemoryError)

`AttachmentHandler.expandVariableAttachments` enumerated the full Cartesian product of every variable attachment node's candidates with no limit:

| file | worst fragment | variable nodes | isomers asked for |
|---|---|---|---|
| m28096433-1 | 33 atoms | 16 | 1.1 × 10⁹ |
| m28096433-4 | 508 atoms | 100 | 8.5 × 10⁶⁹ |

Capped at 1000 combinations; past that the fragment is a generic depiction rather than an enumerable set of substances, so it is skipped with a warning.

## 2. Crossing bonds that never meet

`CDXProp_Bond_CrossingBonds` is a drawing relationship — ChemDraw also names bonds the crossing bond never touches. Every endpoint of every named bond became an attachment candidate, so structures that merely overlap on the page were read as position variations and merged: in m28096433-1 a 3-atom fragment grew to 33 atoms in 8 disconnected components.

The two bonds must now meet — they intersect, or their gap stays within half the crossed bond's length. The threshold comes from the fixtures, not from taste. Over all 248 files in `src/test/resources`, the 300 declared crossing pairs (gap normalised by the crossed bond's length):

| gap | pairs |
|---|---|
| ≤ 0.4 | 292 |
| 0.4 – 0.8 | **0** |
| 0.8 – 1.0 | 8 — all in the two reported files |

Endpoint-distance metrics do not separate these: legitimate stubs in `m31656373-1` sit 0.74–0.85 out, because that idiom draws the substituent bond *through* the bond it attaches to. Only the segment gap does.

## 3. Substituents copied once per crossing bond

A substituent fragment was copied into its scaffold once per bond carrying a crossing reference, and a fragment already merged away kept taking part. m28096433-4 produced a 508-atom fragment of which 396 atoms were duplicates. Now every junction is marked but the atoms and bonds move across once, and a scaffold that has itself been merged away is skipped instead of swallowing atoms that then get dropped. Corpus-wide duplicate atom count: 396 → 0.

## Verification

- `mvn -B verify`: 383 tests, 0 failures. Three new unit tests, each confirmed to fail when its own fix is neutered.
- Both reported files now extract in under a second: 19 and 13 substances.
- Corpus regression run over all 248 fixtures, comparing InChIKey sets before/after: 11 files changed, every one gaining substances, none losing any, no new errors. `m5445236-i5` 2 → 86, `m25534820-i2` 1 → 7. In m28096433-1 the fused chimera `CC1=C2C=CC=CC2=C(C3=CC(=C[N](=C3)*)…` is replaced by the motif it actually is, `C[CH][CH]*`.

## Still open

m28096433-4 keeps one 112-atom fragment: a 44-atom structure whose 10 terminal bonds each cross a bond of a 68-atom scaffold drawn on top of it (both components start at ~(142,62)). Every crossing passes the geometry test, so the heuristic reads 10 variable attachments → 9.8M isomers → the cap skips the fragment with a warning. Most likely two overlapping drawings rather than position variation, but ruling that out needs a structural rule ("a 44-atom fragment with 10 stubs is no substituent") that shouldn't be invented from a single file. Same shape, smaller and now emitting: `m5445236-i5`, 4 junctions → 81 isomers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
